### PR TITLE
Fix mardown syntax and fix indentation to 2spaces tabs (platform independent).

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,19 @@ Tested compilers
 Tested systems:
 - Ubuntu 11.10, 12.04, 12.10
 - Kubuntu 10.04
+- Mint 13
 
 Getting Started
 ---------------------------------------------------
 
 Compiling:
-$] mkdir build
-$] cd build
-$] cmake ..
-$] make
+- $ mkdir build
+- $ cd build
+- $ cmake ..
+- $ make
 
 Additionally you can also install the library in /usr/local/akaze/lib by typing:
-$] sudo make install
+- $ sudo make install
 
 If the compilation is successful you should see three executables in the folder bin:
 - akaze_features
@@ -80,22 +81,22 @@ For running the program you need to type in the command line the following argum
 The options are not mandatory. In case you do not specify additional options, default arguments will be
 used. Here is a description of the additional options:
 
---verbose if verbosity is required
---help for showing the command line options
---soffset the base scale offset (sigma units)
---omax the coarsest nonlinear scale space level (sigma units)
---nsublevels number of sublevels per octave
---diffusivity diffusivity function 0 -> PM 1, 1 -> PM 2, 2 -> Weickert
---dthreshold Feature detector threshold response for accepting points
---descriptor Descriptor Type 0 -> SURF, 1 -> M-SURF, 2 -> M-LDB
---upright 0 -> Rotation Invariant, 1 -> No Rotation Invariant
---descriptor_channels Descriptor Channels for M-LDB. Valid values: 1, 2 (intensity+gradient magnitude), 3(intensity + X and Y gradients)
---descriptor_size Descriptor size for M-LDB in bits. 0 means the full length descriptor (486). Any other value will use a random bit selection
---show_results 1 in case we want to show detection results. 0 otherwise
+- --verbose if verbosity is required
+- --help for showing the command line options
+- --soffset the base scale offset (sigma units)
+- --omax the coarsest nonlinear scale space level (sigma units)
+- --nsublevels number of sublevels per octave
+- --diffusivity diffusivity function 0 -> PM 1, 1 -> PM 2, 2 -> Weickert
+- --dthreshold Feature detector threshold response for accepting points
+- --descriptor Descriptor Type 0 -> SURF, 1 -> M-SURF, 2 -> M-LDB
+- --upright 0 -> Rotation Invariant, 1 -> No Rotation Invariant
+- --descriptor_channels Descriptor Channels for M-LDB. Valid values: 1, 2 (intensity+gradient magnitude), 3(intensity + X and Y gradients)
+- --descriptor_size Descriptor size for M-LDB in bits. 0 means the full length descriptor (486). Any other value will use a random bit selection
+- --show_results 1 in case we want to show detection results. 0 otherwise
 
 Important Things:
-• Check config.h in case you would like to change the value of some default settings
-• The k constrast factor is computed as the 70% percentile of the gradient histogram of a
+- Check config.h in case you would like to change the value of some default settings
+- The k constrast factor is computed as the 70% percentile of the gradient histogram of a
 smoothed version of the original image. Normally, this empirical value gives good results, but
 depending on the input image the diffusion will not be good enough. Therefore I highly
 recommend you to visualize the output images from save_scale_space and test with other k
@@ -121,6 +122,7 @@ For example, with the default configuration parameters used in the current code 
 the following results:
 
 ./akaze_match ../../datasets/iguazu/img1.pgm ../../datasets/iguazu/img4.pgm ../../datasets/iguazu/H1to4p --descriptor 2
+```
 Number of Keypoints Image 1: 1137
 Number of Keypoints Image 2: 1046
 KAZE Features Extraction Time (ms): 228.145
@@ -130,7 +132,7 @@ Number of Matches: 665
 Number of Inliers: 605
 Number of Outliers: 60
 Inliers Ratio: 90.9774
-
+```
 
 Image Matching Comparison between A-KAZE, ORB and BRISK (OpenCV)
 ------------------------------------------------------------------------------------------------------
@@ -149,6 +151,7 @@ For example, running kaze_compare with the first and third images from the boat 
 
 ORB Results
 **************************************
+```
 Number of Keypoints Image 1: 1510
 Number of Keypoints Image 2: 1516
 Number of Matches: 304
@@ -156,9 +159,11 @@ Number of Inliers: 277
 Number of Outliers: 27
 Inliers Ratio: 91.1184
 ORB Features Extraction Time (ms): 74.603
+```
 
 BRISK Results
 **************************************
+```
 Number of Keypoints Image 1: 3457
 Number of Keypoints Image 2: 3031
 Number of Matches: 159
@@ -166,9 +171,11 @@ Number of Inliers: 116
 Number of Outliers: 43
 Inliers Ratio: 72.956
 BRISK Features Extraction Time (ms): 482.781
+```
 
 A-KAZE Results
 **************************************
+```
 Number of Keypoints Image 1: 1549
 Number of Keypoints Image 2: 1193
 Number of Matches: 414
@@ -176,6 +183,7 @@ Number of Inliers: 351
 Number of Outliers: 63
 Inliers Ratio: 84.7826
 A-KAZE Features Extraction Time (ms): 230.502
+```
 
 A-KAZE features is because is open source and you can use that freely even in commercial applications. While A-KAZE is a bit slower compared
 to ORB and BRISK, it provides much better performance. In addition, for images with small resolution such as 640x480 the algorithm can run in real-time.

--- a/src/lib/AKAZE.cpp
+++ b/src/lib/AKAZE.cpp
@@ -35,38 +35,38 @@ using namespace cv;
 */
 AKAZE::AKAZE(const AKAZEOptions &options) {
 
-    soffset_ = options.soffset;
-    factor_size_ = DEFAULT_FACTOR_SIZE;
-    sderivatives_ = DEFAULT_SIGMA_SMOOTHING_DERIVATIVES;
-    omax_ = options.omax;
-    nsublevels_ = options.nsublevels;
-    dthreshold_ = options.dthreshold;
-    descriptor_ = options.descriptor;
-    diffusivity_ = options.diffusivity;
-    save_scale_space_ = options.save_scale_space;
-    verbosity_ = options.verbosity;
-    img_width_ = options.img_width;
-    img_height_ = options.img_height;
-    noctaves_ = omax_;
-    ncycles_ = 0;
-    reordering_ = true;
-    descriptor_size_ = options.descriptor_size;
-    descriptor_channels_ = options.descriptor_channels;
-    descriptor_pattern_size_ = options.descriptor_pattern_size;
-    tkcontrast_ = 0.0;
-    tscale_ = 0.0;
-    tderivatives_ = 0.0;
-    tdetector_ = 0.0;
-    textrema_ = 0.0;
-    tsubpixel_ = 0.0;
-    tdescriptor_ = 0.0;
+  soffset_ = options.soffset;
+  factor_size_ = DEFAULT_FACTOR_SIZE;
+  sderivatives_ = DEFAULT_SIGMA_SMOOTHING_DERIVATIVES;
+  omax_ = options.omax;
+  nsublevels_ = options.nsublevels;
+  dthreshold_ = options.dthreshold;
+  descriptor_ = options.descriptor;
+  diffusivity_ = options.diffusivity;
+  save_scale_space_ = options.save_scale_space;
+  verbosity_ = options.verbosity;
+  img_width_ = options.img_width;
+  img_height_ = options.img_height;
+  noctaves_ = omax_;
+  ncycles_ = 0;
+  reordering_ = true;
+  descriptor_size_ = options.descriptor_size;
+  descriptor_channels_ = options.descriptor_channels;
+  descriptor_pattern_size_ = options.descriptor_pattern_size;
+  tkcontrast_ = 0.0;
+  tscale_ = 0.0;
+  tderivatives_ = 0.0;
+  tdetector_ = 0.0;
+  textrema_ = 0.0;
+  tsubpixel_ = 0.0;
+  tdescriptor_ = 0.0;
 
-    if (descriptor_size_ > 0 && descriptor_ >= MLDB_UPRIGHT) {
-        generateDescriptorSubsample(descriptorSamples_,descriptorBits_,descriptor_size_,
-                                    descriptor_pattern_size_, descriptor_channels_);
-    }
+  if (descriptor_size_ > 0 && descriptor_ >= MLDB_UPRIGHT) {
+    generateDescriptorSubsample(descriptorSamples_,descriptorBits_,descriptor_size_,
+                                descriptor_pattern_size_, descriptor_channels_);
+  }
 
-    Allocate_Memory_Evolution();
+  Allocate_Memory_Evolution();
 }
 
 //*******************************************************************************
@@ -77,7 +77,7 @@ AKAZE::AKAZE(const AKAZEOptions &options) {
 */
 AKAZE::~AKAZE(void) {
 
-    evolution_.clear();
+  evolution_.clear();
 }
 
 //*******************************************************************************
@@ -88,53 +88,53 @@ AKAZE::~AKAZE(void) {
 */
 void AKAZE::Allocate_Memory_Evolution(void) {
 
-    float rfactor = 0.0;
-    int level_height = 0, level_width = 0;
+  float rfactor = 0.0;
+  int level_height = 0, level_width = 0;
 
-    // Allocate the dimension of the matrices for the evolution
-    for (int i = 0; i <= omax_-1 && i <= DEFAULT_OCTAVE_MAX; i++) {
-        rfactor = 1.0/pow(2.f,i);
-        level_height = (int)(img_height_*rfactor);
-        level_width = (int)(img_width_*rfactor);
+  // Allocate the dimension of the matrices for the evolution
+  for (int i = 0; i <= omax_-1 && i <= DEFAULT_OCTAVE_MAX; i++) {
+    rfactor = 1.0/pow(2.f,i);
+    level_height = (int)(img_height_*rfactor);
+    level_width = (int)(img_width_*rfactor);
 
-        // Smallest possible octave
-        if (level_width < 80 || level_height < 40) {
-            noctaves_ = i;
-            i = omax_;
-            break;
-        }
-
-        for (int j = 0; j < nsublevels_; j++) {
-            tevolution aux;
-            aux.Lx  = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Ly  = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Lxx = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Lxy = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Lyy = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Lt  = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Ldet = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Lflow  = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.Lstep  = cv::Mat::zeros(level_height,level_width,CV_32F);
-            aux.esigma = soffset_*pow(2.f,(float)(j)/(float)(nsublevels_) + i);
-            aux.sigma_size = fRound(aux.esigma);
-            aux.etime = 0.5*(aux.esigma*aux.esigma);
-            aux.octave = i;
-            aux.sublevel = j;
-            evolution_.push_back(aux);
-        }
+    // Smallest possible octave
+    if (level_width < 80 || level_height < 40) {
+      noctaves_ = i;
+      i = omax_;
+      break;
     }
 
-    // Allocate memory for the number of cycles and time steps
-    for (size_t i = 1; i < evolution_.size(); i++) {
-        int naux = 0;
-        std::vector<float> tau;
-        float ttime = 0.0;
-        ttime = evolution_[i].etime-evolution_[i-1].etime;
-        naux = fed_tau_by_process_time(ttime,1,0.25,reordering_,tau);
-        nsteps_.push_back(naux);
-        tsteps_.push_back(tau);
-        ncycles_++;
+    for (int j = 0; j < nsublevels_; j++) {
+      tevolution aux;
+      aux.Lx  = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Ly  = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Lxx = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Lxy = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Lyy = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Lt  = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Ldet = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Lflow  = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.Lstep  = cv::Mat::zeros(level_height,level_width,CV_32F);
+      aux.esigma = soffset_*pow(2.f,(float)(j)/(float)(nsublevels_) + i);
+      aux.sigma_size = fRound(aux.esigma);
+      aux.etime = 0.5*(aux.esigma*aux.esigma);
+      aux.octave = i;
+      aux.sublevel = j;
+      evolution_.push_back(aux);
     }
+  }
+
+  // Allocate memory for the number of cycles and time steps
+  for (size_t i = 1; i < evolution_.size(); i++) {
+    int naux = 0;
+    std::vector<float> tau;
+    float ttime = 0.0;
+    ttime = evolution_[i].etime-evolution_[i-1].etime;
+    naux = fed_tau_by_process_time(ttime,1,0.25,reordering_,tau);
+    nsteps_.push_back(naux);
+    tsteps_.push_back(tau);
+    ncycles_++;
+  }
 }
 
 //*******************************************************************************
@@ -147,69 +147,69 @@ void AKAZE::Allocate_Memory_Evolution(void) {
 */
 int AKAZE::Create_Nonlinear_Scale_Space(const cv::Mat &img) {
 
-    double t1 = 0.0, t2 = 0.0;
+  double t1 = 0.0, t2 = 0.0;
 
-    if (evolution_.size() == 0) {
-        cout << "Error generating the nonlinear scale space!!" << endl;
-        cout << "Firstly you need to call AKAZE::Allocate_Memory_Evolution()" << endl;
-        return -1;
+  if (evolution_.size() == 0) {
+    cout << "Error generating the nonlinear scale space!!" << endl;
+    cout << "Firstly you need to call AKAZE::Allocate_Memory_Evolution()" << endl;
+    return -1;
+  }
+
+  t1 = getTickCount();
+
+  // Copy the original image to the first level of the evolution
+  img.copyTo(evolution_[0].Lt);
+  Gaussian_2D_Convolution(evolution_[0].Lt,evolution_[0].Lt,0,0,soffset_);
+  evolution_[0].Lt.copyTo(evolution_[0].Lsmooth);
+
+  // Firstly compute the kcontrast factor
+  kcontrast_ = Compute_K_Percentile(img,KCONTRAST_PERCENTILE,1.0,KCONTRAST_NBINS,0,0);
+
+  t2 = getTickCount();
+  tkcontrast_ = 1000.0*(t2-t1) / getTickFrequency();
+
+  // Now generate the rest of evolution levels
+  for (size_t i = 1; i < evolution_.size(); i++) {
+
+    if (evolution_[i].octave > evolution_[i-1].octave) {
+      Halfsample_Image(evolution_[i-1].Lt,evolution_[i].Lt);
+      kcontrast_ = kcontrast_*0.75;
+    }
+    else {
+      evolution_[i-1].Lt.copyTo(evolution_[i].Lt);
     }
 
-    t1 = getTickCount();
+    Gaussian_2D_Convolution(evolution_[i].Lt,evolution_[i].Lsmooth,0,0,1.0);
 
-    // Copy the original image to the first level of the evolution
-    img.copyTo(evolution_[0].Lt);
-    Gaussian_2D_Convolution(evolution_[0].Lt,evolution_[0].Lt,0,0,soffset_);
-    evolution_[0].Lt.copyTo(evolution_[0].Lsmooth);
+    // Compute the Gaussian derivatives Lx and Ly
+    Image_Derivatives_Scharr(evolution_[i].Lsmooth,evolution_[i].Lx,1,0);
+    Image_Derivatives_Scharr(evolution_[i].Lsmooth,evolution_[i].Ly,0,1);
 
-    // Firstly compute the kcontrast factor
-    kcontrast_ = Compute_K_Percentile(img,KCONTRAST_PERCENTILE,1.0,KCONTRAST_NBINS,0,0);
-
-    t2 = getTickCount();
-    tkcontrast_ = 1000.0*(t2-t1) / getTickFrequency();
-
-    // Now generate the rest of evolution levels
-    for (size_t i = 1; i < evolution_.size(); i++) {
-
-        if (evolution_[i].octave > evolution_[i-1].octave) {
-            Halfsample_Image(evolution_[i-1].Lt,evolution_[i].Lt);
-            kcontrast_ = kcontrast_*0.75;
-        }
-        else {
-            evolution_[i-1].Lt.copyTo(evolution_[i].Lt);
-        }
-
-        Gaussian_2D_Convolution(evolution_[i].Lt,evolution_[i].Lsmooth,0,0,1.0);
-
-        // Compute the Gaussian derivatives Lx and Ly
-        Image_Derivatives_Scharr(evolution_[i].Lsmooth,evolution_[i].Lx,1,0);
-        Image_Derivatives_Scharr(evolution_[i].Lsmooth,evolution_[i].Ly,0,1);
-
-        // Compute the conductivity equation
-        switch( diffusivity_ ) {
-            case 0:
-                PM_G1(evolution_[i].Lx,evolution_[i].Ly,evolution_[i].Lflow,kcontrast_);
-                break;
-            case 1:
-                PM_G2(evolution_[i].Lx,evolution_[i].Ly,evolution_[i].Lflow,kcontrast_);
-                break;
-            case 2:
-                Weickert_Diffusivity(evolution_[i].Lx,evolution_[i].Ly,evolution_[i].Lflow,kcontrast_);
-                break;
-            default:
-                std::cerr << "Diffusivity: " << diffusivity_ << " is not supported" << std::endl;
-        }
-
-        // Perform FED n inner steps
-        for (int j = 0; j < nsteps_[i-1]; j++) {
-            NLD_Step_Scalar(evolution_[i].Lt,evolution_[i].Lflow,evolution_[i].Lstep,tsteps_[i-1][j]);
-        }
+    // Compute the conductivity equation
+    switch( diffusivity_ ) {
+    case 0:
+      PM_G1(evolution_[i].Lx,evolution_[i].Ly,evolution_[i].Lflow,kcontrast_);
+      break;
+    case 1:
+      PM_G2(evolution_[i].Lx,evolution_[i].Ly,evolution_[i].Lflow,kcontrast_);
+      break;
+    case 2:
+      Weickert_Diffusivity(evolution_[i].Lx,evolution_[i].Ly,evolution_[i].Lflow,kcontrast_);
+      break;
+    default:
+      std::cerr << "Diffusivity: " << diffusivity_ << " is not supported" << std::endl;
     }
 
-    t2 = getTickCount();
-    tscale_ = 1000.0*(t2-t1) / getTickFrequency();
+    // Perform FED n inner steps
+    for (int j = 0; j < nsteps_[i-1]; j++) {
+      NLD_Step_Scalar(evolution_[i].Lt,evolution_[i].Lflow,evolution_[i].Lstep,tsteps_[i-1][j]);
+    }
+  }
 
-    return 0;
+  t2 = getTickCount();
+  tscale_ = 1000.0*(t2-t1) / getTickFrequency();
+
+  return 0;
 }
 
 //*************************************************************************************
@@ -221,16 +221,16 @@ int AKAZE::Create_Nonlinear_Scale_Space(const cv::Mat &img) {
 */
 void AKAZE::Feature_Detection(std::vector<cv::KeyPoint> &kpts) {
 
-    double t1 = 0.0, t2 = 0.0;
+  double t1 = 0.0, t2 = 0.0;
 
-    t1 = getTickCount();
+  t1 = getTickCount();
 
-    Compute_Determinant_Hessian_Response();
-    Find_Scale_Space_Extrema(kpts);
-    Do_Subpixel_Refinement(kpts);
+  Compute_Determinant_Hessian_Response();
+  Find_Scale_Space_Extrema(kpts);
+  Do_Subpixel_Refinement(kpts);
 
-    t2 = getTickCount();
-    tdetector_ = 1000.0*(t2-t1) / getTickFrequency();
+  t2 = getTickCount();
+  tdetector_ = 1000.0*(t2-t1) / getTickFrequency();
 }
 
 //*************************************************************************************
@@ -241,32 +241,32 @@ void AKAZE::Feature_Detection(std::vector<cv::KeyPoint> &kpts) {
 */
 void AKAZE::Compute_Multiscale_Derivatives(void) {
 
-    double t1 = 0.0, t2 = 0.0;
+  double t1 = 0.0, t2 = 0.0;
 
-    t1 = getTickCount();
+  t1 = getTickCount();
 
-    #ifdef _OPENMP
-    #pragma omp parallel for
-    #endif
-    for (size_t i = 0; i < evolution_.size(); i++) {
-        float ratio = pow(2,evolution_[i].octave);
-        int sigma_size_ = fRound(evolution_[i].esigma*factor_size_/ratio);
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (size_t i = 0; i < evolution_.size(); i++) {
+    float ratio = pow(2,evolution_[i].octave);
+    int sigma_size_ = fRound(evolution_[i].esigma*factor_size_/ratio);
 
-        Compute_Scharr_Derivatives(evolution_[i].Lsmooth,evolution_[i].Lx,1,0,sigma_size_);
-        Compute_Scharr_Derivatives(evolution_[i].Lsmooth,evolution_[i].Ly,0,1,sigma_size_);
-        Compute_Scharr_Derivatives(evolution_[i].Lx,evolution_[i].Lxx,1,0,sigma_size_);
-        Compute_Scharr_Derivatives(evolution_[i].Ly,evolution_[i].Lyy,0,1,sigma_size_);
-        Compute_Scharr_Derivatives(evolution_[i].Lx,evolution_[i].Lxy,0,1,sigma_size_);
+    Compute_Scharr_Derivatives(evolution_[i].Lsmooth,evolution_[i].Lx,1,0,sigma_size_);
+    Compute_Scharr_Derivatives(evolution_[i].Lsmooth,evolution_[i].Ly,0,1,sigma_size_);
+    Compute_Scharr_Derivatives(evolution_[i].Lx,evolution_[i].Lxx,1,0,sigma_size_);
+    Compute_Scharr_Derivatives(evolution_[i].Ly,evolution_[i].Lyy,0,1,sigma_size_);
+    Compute_Scharr_Derivatives(evolution_[i].Lx,evolution_[i].Lxy,0,1,sigma_size_);
 
-        evolution_[i].Lx = evolution_[i].Lx*((sigma_size_));
-        evolution_[i].Ly = evolution_[i].Ly*((sigma_size_));
-        evolution_[i].Lxx = evolution_[i].Lxx*((sigma_size_)*(sigma_size_));
-        evolution_[i].Lxy = evolution_[i].Lxy*((sigma_size_)*(sigma_size_));
-        evolution_[i].Lyy = evolution_[i].Lyy*((sigma_size_)*(sigma_size_));
-    }
+    evolution_[i].Lx = evolution_[i].Lx*((sigma_size_));
+    evolution_[i].Ly = evolution_[i].Ly*((sigma_size_));
+    evolution_[i].Lxx = evolution_[i].Lxx*((sigma_size_)*(sigma_size_));
+    evolution_[i].Lxy = evolution_[i].Lxy*((sigma_size_)*(sigma_size_));
+    evolution_[i].Lyy = evolution_[i].Lyy*((sigma_size_)*(sigma_size_));
+  }
 
-    t2 = getTickCount();
-    tderivatives_ = 1000.0*(t2-t1) / getTickFrequency();
+  t2 = getTickCount();
+  tderivatives_ = 1000.0*(t2-t1) / getTickFrequency();
 }
 
 //*************************************************************************************
@@ -278,23 +278,23 @@ void AKAZE::Compute_Multiscale_Derivatives(void) {
 */
 void AKAZE::Compute_Determinant_Hessian_Response(void) {
 
-    // Firstly compute the multiscale derivatives
-    Compute_Multiscale_Derivatives();
+  // Firstly compute the multiscale derivatives
+  Compute_Multiscale_Derivatives();
 
-    for (size_t i = 0; i < evolution_.size(); i++){
-        if (verbosity_ == true) {
-            cout << "Computing detector response. Determinant of Hessian. Evolution time: " << evolution_[i].etime << endl;
-        }
+  for (size_t i = 0; i < evolution_.size(); i++) {
+    if (verbosity_ == true) {
+      cout << "Computing detector response. Determinant of Hessian. Evolution time: " << evolution_[i].etime << endl;
+    }
 
-        for (int ix = 0; ix < evolution_[i].Ldet.rows; ix++) {
-            for (int jx = 0; jx < evolution_[i].Ldet.cols; jx++) {
-                float lxx = *(evolution_[i].Lxx.ptr<float>(ix)+jx);
-                float lxy = *(evolution_[i].Lxy.ptr<float>(ix)+jx);
-                float lyy = *(evolution_[i].Lyy.ptr<float>(ix)+jx);
-                *(evolution_[i].Ldet.ptr<float>(ix)+jx) = (lxx*lyy-lxy*lxy);
-            } //for iy
-        } // for ix
-    } // for i
+    for (int ix = 0; ix < evolution_[i].Ldet.rows; ix++) {
+      for (int jx = 0; jx < evolution_[i].Ldet.cols; jx++) {
+        float lxx = *(evolution_[i].Lxx.ptr<float>(ix)+jx);
+        float lxy = *(evolution_[i].Lxy.ptr<float>(ix)+jx);
+        float lyy = *(evolution_[i].Lyy.ptr<float>(ix)+jx);
+        *(evolution_[i].Ldet.ptr<float>(ix)+jx) = (lxx*lyy-lxy*lxy);
+      } //for iy
+    } // for ix
+  } // for i
 }
 
 //*************************************************************************************
@@ -306,105 +306,105 @@ void AKAZE::Compute_Determinant_Hessian_Response(void) {
 */
 void AKAZE::Find_Scale_Space_Extrema(std::vector<cv::KeyPoint> &kpts) {
 
-    double t1 = 0.0, t2 = 0.0;
-    float value = 0.0;
-    float dist = 0.0, ratio = 0.0, smax = 0.0;
-    int npoints = 0, id_repeated = 0;
-    int sigma_size_ = 0, left_x = 0, right_x = 0, up_y = 0, down_y = 0;
-    bool is_extremum = false, is_repeated = false, is_out = false;
-    cv::KeyPoint point;
+  double t1 = 0.0, t2 = 0.0;
+  float value = 0.0;
+  float dist = 0.0, ratio = 0.0, smax = 0.0;
+  int npoints = 0, id_repeated = 0;
+  int sigma_size_ = 0, left_x = 0, right_x = 0, up_y = 0, down_y = 0;
+  bool is_extremum = false, is_repeated = false, is_out = false;
+  cv::KeyPoint point;
 
-    // Set maximum size
-    if (descriptor_ == SURF_UPRIGHT || descriptor_ == SURF || descriptor_ == MLDB_UPRIGHT || descriptor_ == MLDB) {
-        smax = 10.0*sqrtf(2.0);
-    }
-    else if (descriptor_ == MSURF_UPRIGHT || descriptor_ == MSURF) {
-        smax = 12.0*sqrtf(2.0);
-    }
+  // Set maximum size
+  if (descriptor_ == SURF_UPRIGHT || descriptor_ == SURF || descriptor_ == MLDB_UPRIGHT || descriptor_ == MLDB) {
+    smax = 10.0*sqrtf(2.0);
+  }
+  else if (descriptor_ == MSURF_UPRIGHT || descriptor_ == MSURF) {
+    smax = 12.0*sqrtf(2.0);
+  }
 
-    t1 = getTickCount();
+  t1 = getTickCount();
 
-    for (size_t i = 0; i < evolution_.size(); i++) {
-        for (int ix = 1; ix < evolution_[i].Ldet.rows-1; ix++) {
-            for (int jx = 1; jx < evolution_[i].Ldet.cols-1; jx++) {
-                is_extremum = false;
-                is_repeated = false;
-                is_out = false;
-                value = *(evolution_[i].Ldet.ptr<float>(ix)+jx);
+  for (size_t i = 0; i < evolution_.size(); i++) {
+    for (int ix = 1; ix < evolution_[i].Ldet.rows-1; ix++) {
+      for (int jx = 1; jx < evolution_[i].Ldet.cols-1; jx++) {
+        is_extremum = false;
+        is_repeated = false;
+        is_out = false;
+        value = *(evolution_[i].Ldet.ptr<float>(ix)+jx);
 
-                // Filter the points with the detector threshold
-                if (value > dthreshold_ && value >= DEFAULT_MIN_DETECTOR_THRESHOLD &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix)+jx-1) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix)+jx+1) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix-1)+jx-1) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix-1)+jx) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix-1)+jx+1) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix+1)+jx-1) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix+1)+jx) &&
-                        value > *(evolution_[i].Ldet.ptr<float>(ix+1)+jx+1)) {
-                    is_extremum = true;
+        // Filter the points with the detector threshold
+        if (value > dthreshold_ && value >= DEFAULT_MIN_DETECTOR_THRESHOLD &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix)+jx-1) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix)+jx+1) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix-1)+jx-1) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix-1)+jx) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix-1)+jx+1) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix+1)+jx-1) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix+1)+jx) &&
+            value > *(evolution_[i].Ldet.ptr<float>(ix+1)+jx+1)) {
+          is_extremum = true;
 
-                    point.response = fabs(value);
-                    point.size = evolution_[i].esigma*factor_size_;
-                    point.octave = evolution_[i].octave;
-                    point.class_id = i;
-                    ratio = pow(2.f,point.octave);
-                    sigma_size_ = fRound(point.size/ratio);
-                    point.pt.x = jx;
-                    point.pt.y = ix;
+          point.response = fabs(value);
+          point.size = evolution_[i].esigma*factor_size_;
+          point.octave = evolution_[i].octave;
+          point.class_id = i;
+          ratio = pow(2.f,point.octave);
+          sigma_size_ = fRound(point.size/ratio);
+          point.pt.x = jx;
+          point.pt.y = ix;
 
-                    for (size_t ik = 0; ik < kpts.size(); ik++) {
-                        if (point.class_id == kpts[ik].class_id-1 ||
-                                point.class_id == kpts[ik].class_id   ||
-                                point.class_id == kpts[ik].class_id+1) {
-                            dist = sqrt(pow(point.pt.x*ratio-kpts[ik].pt.x,2)+pow(point.pt.y*ratio-kpts[ik].pt.y,2));
-                            if (dist <= point.size) {
-                                if (point.response > kpts[ik].response) {
-                                    id_repeated = ik;
-                                    is_repeated = true;
-                                }
-                                else {
-                                    is_extremum = false;
-                                }
-                                break;
-                            }
-                        }
-                    } // for ik
-
-                    // Check out of bounds
-                    if (is_extremum == true) {
-                        // Check that the point is under the image limits for the descriptor computation
-                        left_x = fRound(point.pt.x-smax*sigma_size_)-1;
-                        right_x = fRound(point.pt.x+smax*sigma_size_) +1;
-                        up_y = fRound(point.pt.y-smax*sigma_size_)-1;
-                        down_y = fRound(point.pt.y+smax*sigma_size_)+1;
-
-                        if (left_x < 0 || right_x >= evolution_[i].Ldet.cols ||
-                            up_y < 0 || down_y >= evolution_[i].Ldet.rows) {
-                            is_out = true;
-                        }
-
-                        if (is_out == false) {
-                            if (is_repeated == false) {
-                                point.pt.x *= ratio;
-                                point.pt.y *= ratio;
-                                kpts.push_back(point);
-                                npoints++;
-                            }
-                            else {
-                                point.pt.x *= ratio;
-                                point.pt.y *= ratio;
-                                kpts[id_repeated] = point;
-                            }
-                        } // if is_out
-                    } //if is_extremum
+          for (size_t ik = 0; ik < kpts.size(); ik++) {
+            if (point.class_id == kpts[ik].class_id-1 ||
+                point.class_id == kpts[ik].class_id   ||
+                point.class_id == kpts[ik].class_id+1) {
+              dist = sqrt(pow(point.pt.x*ratio-kpts[ik].pt.x,2)+pow(point.pt.y*ratio-kpts[ik].pt.y,2));
+              if (dist <= point.size) {
+                if (point.response > kpts[ik].response) {
+                  id_repeated = ik;
+                  is_repeated = true;
                 }
-            } // for jx
-        } // for ix
-    } // for i
+                else {
+                  is_extremum = false;
+                }
+                break;
+              }
+            }
+          } // for ik
 
-    t2 = getTickCount();
-    textrema_ = 1000.0*(t2-t1) / getTickFrequency();
+          // Check out of bounds
+          if (is_extremum == true) {
+            // Check that the point is under the image limits for the descriptor computation
+            left_x = fRound(point.pt.x-smax*sigma_size_)-1;
+            right_x = fRound(point.pt.x+smax*sigma_size_) +1;
+            up_y = fRound(point.pt.y-smax*sigma_size_)-1;
+            down_y = fRound(point.pt.y+smax*sigma_size_)+1;
+
+            if (left_x < 0 || right_x >= evolution_[i].Ldet.cols ||
+                up_y < 0 || down_y >= evolution_[i].Ldet.rows) {
+              is_out = true;
+            }
+
+            if (is_out == false) {
+              if (is_repeated == false) {
+                point.pt.x *= ratio;
+                point.pt.y *= ratio;
+                kpts.push_back(point);
+                npoints++;
+              }
+              else {
+                point.pt.x *= ratio;
+                point.pt.y *= ratio;
+                kpts[id_repeated] = point;
+              }
+            } // if is_out
+          } //if is_extremum
+        }
+      } // for jx
+    } // for ix
+  } // for i
+
+  t2 = getTickCount();
+  textrema_ = 1000.0*(t2-t1) / getTickFrequency();
 }
 
 //*************************************************************************************
@@ -416,69 +416,69 @@ void AKAZE::Find_Scale_Space_Extrema(std::vector<cv::KeyPoint> &kpts) {
 */
 void AKAZE::Do_Subpixel_Refinement(std::vector<cv::KeyPoint> &kpts) {
 
-    double t1 = 0.0, t2 = 0.0;
-    float Dx = 0.0, Dy = 0.0, ratio = 0.0;
-    float Dxx = 0.0, Dyy = 0.0, Dxy = 0.0;
-    int x = 0, y = 0;
-    cv::Mat A = Mat::zeros(2,2,CV_32F);
-    cv::Mat b = Mat::zeros(2,1,CV_32F);
-    cv::Mat dst = Mat::zeros(2,1,CV_32F);
+  double t1 = 0.0, t2 = 0.0;
+  float Dx = 0.0, Dy = 0.0, ratio = 0.0;
+  float Dxx = 0.0, Dyy = 0.0, Dxy = 0.0;
+  int x = 0, y = 0;
+  cv::Mat A = Mat::zeros(2,2,CV_32F);
+  cv::Mat b = Mat::zeros(2,1,CV_32F);
+  cv::Mat dst = Mat::zeros(2,1,CV_32F);
 
-    t1 = getTickCount();
+  t1 = getTickCount();
 
-    for (size_t i = 0; i < kpts.size(); i++) {
-        ratio = pow(2.f,kpts[i].octave);
-        x = fRound(kpts[i].pt.x/ratio);
-        y = fRound(kpts[i].pt.y/ratio);
+  for (size_t i = 0; i < kpts.size(); i++) {
+    ratio = pow(2.f,kpts[i].octave);
+    x = fRound(kpts[i].pt.x/ratio);
+    y = fRound(kpts[i].pt.y/ratio);
 
-        // Compute the gradient
-        Dx = (0.5)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x+1)
-                    -*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x-1));
-        Dy = (0.5)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x)
-                    -*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x));
+    // Compute the gradient
+    Dx = (0.5)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x+1)
+                -*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x-1));
+    Dy = (0.5)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x)
+                -*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x));
 
-        // Compute the Hessian
-        Dxx = (*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x+1)
-               + *(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x-1)
-               -2.0*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x)));
+    // Compute the Hessian
+    Dxx = (*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x+1)
+           + *(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x-1)
+           -2.0*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x)));
 
-        Dyy = (*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x)
-               + *(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x)
-               -2.0*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x)));
+    Dyy = (*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x)
+           + *(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x)
+           -2.0*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y)+x)));
 
-        Dxy = (0.25)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x+1)
-                      +(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x-1)))
-                -(0.25)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x+1)
-                         +(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x-1)));
+    Dxy = (0.25)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x+1)
+                  +(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x-1)))
+          -(0.25)*(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y-1)+x+1)
+                   +(*(evolution_[kpts[i].class_id].Ldet.ptr<float>(y+1)+x-1)));
 
-        // Solve the linear system
-        *(A.ptr<float>(0)) = Dxx;
-        *(A.ptr<float>(1)+1) = Dyy;
-        *(A.ptr<float>(0)+1) = *(A.ptr<float>(1)) = Dxy;
-        *(b.ptr<float>(0)) = -Dx;
-        *(b.ptr<float>(1)) = -Dy;
+    // Solve the linear system
+    *(A.ptr<float>(0)) = Dxx;
+    *(A.ptr<float>(1)+1) = Dyy;
+    *(A.ptr<float>(0)+1) = *(A.ptr<float>(1)) = Dxy;
+    *(b.ptr<float>(0)) = -Dx;
+    *(b.ptr<float>(1)) = -Dy;
 
-        cv::solve(A,b,dst,DECOMP_LU);
+    cv::solve(A,b,dst,DECOMP_LU);
 
-        if (fabs(*(dst.ptr<float>(0))) <= 1.0 && fabs(*(dst.ptr<float>(1))) <= 1.0) {
-            kpts[i].pt.x = x + (*(dst.ptr<float>(0)));
-            kpts[i].pt.y = y + (*(dst.ptr<float>(1)));
-            kpts[i].pt.x *= powf(2.f,evolution_[kpts[i].class_id].octave);
-            kpts[i].pt.y *= powf(2.f,evolution_[kpts[i].class_id].octave);
-            kpts[i].angle = 0.0;
+    if (fabs(*(dst.ptr<float>(0))) <= 1.0 && fabs(*(dst.ptr<float>(1))) <= 1.0) {
+      kpts[i].pt.x = x + (*(dst.ptr<float>(0)));
+      kpts[i].pt.y = y + (*(dst.ptr<float>(1)));
+      kpts[i].pt.x *= powf(2.f,evolution_[kpts[i].class_id].octave);
+      kpts[i].pt.y *= powf(2.f,evolution_[kpts[i].class_id].octave);
+      kpts[i].angle = 0.0;
 
-            // In OpenCV the size of a keypoint its the diameter
-            kpts[i].size *= 2.0;
-        }
-        // Delete the point since its not stable
-        else {
-            kpts.erase(kpts.begin()+i);
-            i--;
-        }
-    } // for i
+      // In OpenCV the size of a keypoint its the diameter
+      kpts[i].size *= 2.0;
+    }
+    // Delete the point since its not stable
+    else {
+      kpts.erase(kpts.begin()+i);
+      i--;
+    }
+  } // for i
 
-    t2 = getTickCount();
-    tsubpixel_ = 1000.0*(t2-t1) / getTickFrequency();
+  t2 = getTickCount();
+  tsubpixel_ = 1000.0*(t2-t1) / getTickFrequency();
 }
 
 //*************************************************************************************
@@ -490,52 +490,52 @@ void AKAZE::Do_Subpixel_Refinement(std::vector<cv::KeyPoint> &kpts) {
  * @param mdist Maximum distance in pixels
 */
 void AKAZE::Feature_Suppression_Distance(std::vector<cv::KeyPoint> &kpts, const float& mdist) {
-    vector<KeyPoint> aux;
-    vector<int> to_delete;
-    float dist = 0.0, x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = 0.0;
-    bool found = false;
+  vector<KeyPoint> aux;
+  vector<int> to_delete;
+  float dist = 0.0, x1 = 0.0, y1 = 0.0, x2 = 0.0, y2 = 0.0;
+  bool found = false;
 
-    for (size_t i = 0; i < kpts.size(); i++) {
+  for (size_t i = 0; i < kpts.size(); i++) {
 
-         x1 = kpts[i].pt.x;
-         y1 = kpts[i].pt.y;
+    x1 = kpts[i].pt.x;
+    y1 = kpts[i].pt.y;
 
-         for (size_t j = i+1; j < kpts.size(); j++) {
+    for (size_t j = i+1; j < kpts.size(); j++) {
 
-             x2 = kpts[j].pt.x;
-             y2 = kpts[j].pt.y;
-             dist = sqrt(pow(x1-x2,2)+pow(y1-y2,2));
+      x2 = kpts[j].pt.x;
+      y2 = kpts[j].pt.y;
+      dist = sqrt(pow(x1-x2,2)+pow(y1-y2,2));
 
-             if (dist < mdist) {
-                  if (fabs(kpts[i].response) >= fabs(kpts[j].response)) {
-                      to_delete.push_back(j);
-                  }
-                  else {
-                      to_delete.push_back(i);
-                      break;
-                  }
-             }
-         }
+      if (dist < mdist) {
+        if (fabs(kpts[i].response) >= fabs(kpts[j].response)) {
+          to_delete.push_back(j);
+        }
+        else {
+          to_delete.push_back(i);
+          break;
+        }
+      }
+    }
+  }
+
+  for (size_t i = 0; i < kpts.size(); i++) {
+    found = false;
+
+    for (size_t j = 0; j < to_delete.size(); j++) {
+      if (i == (size_t)(to_delete[j])) {
+        found = true;
+        break;
+      }
     }
 
-    for (size_t i = 0; i < kpts.size(); i++) {
-         found = false;
-
-         for (size_t j = 0; j < to_delete.size(); j++) {
-             if (i == (size_t)(to_delete[j])) {
-                 found = true;
-                 break;
-             }
-         }
-
-         if (found == false) {
-             aux.push_back(kpts[i]);
-         }
+    if (found == false) {
+      aux.push_back(kpts[i]);
     }
+  }
 
-    kpts.clear();
-    kpts = aux;
-    aux.clear();
+  kpts.clear();
+  kpts = aux;
+  aux.clear();
 }
 
 //*************************************************************************************
@@ -548,101 +548,101 @@ void AKAZE::Feature_Suppression_Distance(std::vector<cv::KeyPoint> &kpts, const 
 */
 void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint> &kpts, cv::Mat &desc) {
 
-    double t1 = 0.0, t2 = 0.0;
+  double t1 = 0.0, t2 = 0.0;
 
-    t1 = getTickCount();
+  t1 = getTickCount();
 
-    // Allocate memory for the matrix with the descriptors
-    if (descriptor_ < MLDB_UPRIGHT) {
-        desc = cv::Mat::zeros(kpts.size(),64,CV_32FC1);
+  // Allocate memory for the matrix with the descriptors
+  if (descriptor_ < MLDB_UPRIGHT) {
+    desc = cv::Mat::zeros(kpts.size(),64,CV_32FC1);
+  }
+  else {
+    // We use the full length binary descriptor -> 486 bits
+    if (descriptor_size_ == 0) {
+      int t = (6+36+120)*descriptor_channels_;
+      desc = cv::Mat::zeros(kpts.size(),ceil(t/8.),CV_8UC1);
     }
     else {
-        // We use the full length binary descriptor -> 486 bits
-        if (descriptor_size_ == 0) {
-            int t = (6+36+120)*descriptor_channels_;
-            desc = cv::Mat::zeros(kpts.size(),ceil(t/8.),CV_8UC1);
-        }
-        else {
-            // We use the random bit selection length binary descriptor
-            desc = cv::Mat::zeros(kpts.size(),ceil(descriptor_size_/8.),CV_8UC1);
-        }
+      // We use the random bit selection length binary descriptor
+      desc = cv::Mat::zeros(kpts.size(),ceil(descriptor_size_/8.),CV_8UC1);
     }
+  }
 
-    switch (descriptor_)
+  switch (descriptor_)
+  {
+  case SURF_UPRIGHT : // Upright descriptors, not invariant to rotation
     {
-        case SURF_UPRIGHT : // Upright descriptors, not invariant to rotation
-        {
-            #ifdef _OPENMP
-            #pragma omp parallel for
-            #endif
-            for (size_t i = 0; i < kpts.size(); i++) {
-                Get_SURF_Descriptor_Upright_64(kpts[i],desc.ptr<float>(i));
-            }
-        }
-        break;
-        case SURF :
-        {
-            #ifdef _OPENMP
-            #pragma omp parallel for
-            #endif
-            for (size_t i = 0; i < kpts.size(); i++) {
-                Compute_Main_Orientation_SURF(kpts[i]);
-                Get_SURF_Descriptor_64(kpts[i],desc.ptr<float>(i));
-            }
-        }
-        break;
-        case MSURF_UPRIGHT : // Upright descriptors, not invariant to rotation
-        {
-            #ifdef _OPENMP
-            #pragma omp parallel for
-            #endif
-            for (size_t i = 0; i < kpts.size(); i++) {
-                Get_MSURF_Upright_Descriptor_64(kpts[i],desc.ptr<float>(i));
-            }
-        }
-        break;
-        case MSURF :
-        {
-            #ifdef _OPENMP
-            #pragma omp parallel for
-            #endif
-            for (size_t i = 0; i < kpts.size(); i++) {
-                Compute_Main_Orientation_SURF(kpts[i]);
-                Get_MSURF_Descriptor_64(kpts[i],desc.ptr<float>(i));
-            }
-        }
-        break;
-        case MLDB_UPRIGHT : // Upright descriptors, not invariant to rotation
-        {
-            #ifdef _OPENMP
-            #pragma omp parallel for
-            #endif
-            for (size_t i = 0; i < kpts.size(); i++) {
-                if (descriptor_size_ == 0)
-                    Get_Upright_MLDB_Full_Descriptor(kpts[i],desc.ptr<unsigned char>(i));
-                else
-                    Get_Upright_MLDB_Descriptor_Subset(kpts[i],desc.ptr<unsigned char>(i));
-            }
-        }
-        break;
-        case MLDB :
-        {
-            #ifdef _OPENMP
-            #pragma omp parallel for
-            #endif
-            for (size_t i = 0; i < kpts.size(); i++) {
-                Compute_Main_Orientation_SURF(kpts[i]);
-                if (descriptor_size_ == 0)
-                    Get_MLDB_Full_Descriptor(kpts[i],desc.ptr<unsigned char>(i));
-                else
-                    Get_MLDB_Descriptor_Subset(kpts[i],desc.ptr<unsigned char>(i));
-            }
-        }
-        break;
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < kpts.size(); i++) {
+        Get_SURF_Descriptor_Upright_64(kpts[i],desc.ptr<float>(i));
+      }
     }
+    break;
+  case SURF :
+    {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < kpts.size(); i++) {
+        Compute_Main_Orientation_SURF(kpts[i]);
+        Get_SURF_Descriptor_64(kpts[i],desc.ptr<float>(i));
+      }
+    }
+    break;
+  case MSURF_UPRIGHT : // Upright descriptors, not invariant to rotation
+    {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < kpts.size(); i++) {
+        Get_MSURF_Upright_Descriptor_64(kpts[i],desc.ptr<float>(i));
+      }
+    }
+    break;
+  case MSURF :
+    {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < kpts.size(); i++) {
+        Compute_Main_Orientation_SURF(kpts[i]);
+        Get_MSURF_Descriptor_64(kpts[i],desc.ptr<float>(i));
+      }
+    }
+    break;
+  case MLDB_UPRIGHT : // Upright descriptors, not invariant to rotation
+    {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < kpts.size(); i++) {
+        if (descriptor_size_ == 0)
+          Get_Upright_MLDB_Full_Descriptor(kpts[i],desc.ptr<unsigned char>(i));
+        else
+          Get_Upright_MLDB_Descriptor_Subset(kpts[i],desc.ptr<unsigned char>(i));
+      }
+    }
+    break;
+  case MLDB :
+    {
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+      for (size_t i = 0; i < kpts.size(); i++) {
+        Compute_Main_Orientation_SURF(kpts[i]);
+        if (descriptor_size_ == 0)
+          Get_MLDB_Full_Descriptor(kpts[i],desc.ptr<unsigned char>(i));
+        else
+          Get_MLDB_Descriptor_Subset(kpts[i],desc.ptr<unsigned char>(i));
+      }
+    }
+    break;
+  }
 
-    t2 = getTickCount();
-    tdescriptor_ = 1000.0*(t2-t1) / getTickFrequency();
+  t2 = getTickCount();
+  tdescriptor_ = 1000.0*(t2-t1) / getTickFrequency();
 }
 
 //*************************************************************************************
@@ -656,67 +656,67 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint> &kpts, cv::Mat &desc) 
 */
 void AKAZE::Compute_Main_Orientation_SURF(cv::KeyPoint &kpt) {
 
-    int ix = 0, iy = 0, idx = 0, s = 0, level = 0;
-    float xf = 0.0, yf = 0.0, gweight = 0.0, ratio = 0.0;
-    std::vector<float> resX(109), resY(109), Ang(109);
-    const int id[] = {6,5,4,3,2,1,0,1,2,3,4,5,6};
+  int ix = 0, iy = 0, idx = 0, s = 0, level = 0;
+  float xf = 0.0, yf = 0.0, gweight = 0.0, ratio = 0.0;
+  std::vector<float> resX(109), resY(109), Ang(109);
+  const int id[] = {6,5,4,3,2,1,0,1,2,3,4,5,6};
 
-    // Variables for computing the dominant direction
-    float sumX = 0.0, sumY = 0.0, max = 0.0, ang1 = 0.0, ang2 = 0.0;
+  // Variables for computing the dominant direction
+  float sumX = 0.0, sumY = 0.0, max = 0.0, ang1 = 0.0, ang2 = 0.0;
 
-    // Get the information from the keypoint
-    level = kpt.class_id;
-    ratio = (float)(1<<evolution_[level].octave);
-    s = fRound(0.5*kpt.size/ratio);
-    xf = kpt.pt.x/ratio;
-    yf = kpt.pt.y/ratio;
+  // Get the information from the keypoint
+  level = kpt.class_id;
+  ratio = (float)(1<<evolution_[level].octave);
+  s = fRound(0.5*kpt.size/ratio);
+  xf = kpt.pt.x/ratio;
+  yf = kpt.pt.y/ratio;
 
-    // Calculate derivatives responses for points within radius of 6*scale
-    for (int i = -6; i <= 6; ++i) {
-        for (int j = -6; j <= 6; ++j) {
-            if (i*i + j*j < 36) {
-                iy = fRound(yf + j*s);
-                ix = fRound(xf + i*s);
+  // Calculate derivatives responses for points within radius of 6*scale
+  for (int i = -6; i <= 6; ++i) {
+    for (int j = -6; j <= 6; ++j) {
+      if (i*i + j*j < 36) {
+        iy = fRound(yf + j*s);
+        ix = fRound(xf + i*s);
 
-                gweight = gauss25[id[i+6]][id[j+6]];
-                resX[idx] = gweight*(*(evolution_[level].Lx.ptr<float>(iy)+ix));
-                resY[idx] = gweight*(*(evolution_[level].Ly.ptr<float>(iy)+ix));
+        gweight = gauss25[id[i+6]][id[j+6]];
+        resX[idx] = gweight*(*(evolution_[level].Lx.ptr<float>(iy)+ix));
+        resY[idx] = gweight*(*(evolution_[level].Ly.ptr<float>(iy)+ix));
 
-                Ang[idx] = get_angle(resX[idx],resY[idx]);
-                ++idx;
-            }
-        }
+        Ang[idx] = get_angle(resX[idx],resY[idx]);
+        ++idx;
+      }
+    }
+  }
+
+  // Loop slides pi/3 window around feature point
+  for (ang1 = 0; ang1 < 2.0*CV_PI;  ang1+=0.15f) {
+    ang2 =(ang1+CV_PI/3.0f > 2.0*CV_PI ? ang1-5.0f*CV_PI/3.0f : ang1+CV_PI/3.0f);
+    sumX = sumY = 0.f;
+
+    for (size_t k = 0; k < Ang.size(); ++k) {
+      // Get angle from the x-axis of the sample point
+      const float & ang = Ang[k];
+
+      // Determine whether the point is within the window
+      if (ang1 < ang2 && ang1 < ang && ang < ang2) {
+        sumX+=resX[k];
+        sumY+=resY[k];
+      }
+      else if (ang2 < ang1 &&
+               ((ang > 0 && ang < ang2) || (ang > ang1 && ang < 2.0*CV_PI) )) {
+        sumX+=resX[k];
+        sumY+=resY[k];
+      }
     }
 
-    // Loop slides pi/3 window around feature point
-    for (ang1 = 0; ang1 < 2.0*CV_PI;  ang1+=0.15f) {
-        ang2 =(ang1+CV_PI/3.0f > 2.0*CV_PI ? ang1-5.0f*CV_PI/3.0f : ang1+CV_PI/3.0f);
-        sumX = sumY = 0.f;
-
-        for (size_t k = 0; k < Ang.size(); ++k) {
-            // Get angle from the x-axis of the sample point
-            const float & ang = Ang[k];
-
-            // Determine whether the point is within the window
-            if (ang1 < ang2 && ang1 < ang && ang < ang2) {
-                sumX+=resX[k];
-                sumY+=resY[k];
-            }
-            else if (ang2 < ang1 &&
-                     ((ang > 0 && ang < ang2) || (ang > ang1 && ang < 2.0*CV_PI) )) {
-                sumX+=resX[k];
-                sumY+=resY[k];
-            }
-        }
-
-        // if the vector produced from this window is longer than all
-        // previous vectors then this forms the new dominant direction
-        if (sumX*sumX + sumY*sumY > max) {
-            // store largest orientation
-            max = sumX*sumX + sumY*sumY;
-            kpt.angle = get_angle(sumX, sumY);
-        }
+    // if the vector produced from this window is longer than all
+    // previous vectors then this forms the new dominant direction
+    if (sumX*sumX + sumY*sumY > max) {
+      // store largest orientation
+      max = sumX*sumX + sumY*sumY;
+      kpt.angle = get_angle(sumX, sumY);
     }
+  }
 }
 
 //*************************************************************************************
@@ -731,82 +731,82 @@ void AKAZE::Compute_Main_Orientation_SURF(cv::KeyPoint &kpt) {
 */
 void AKAZE::Get_SURF_Descriptor_Upright_64(const cv::KeyPoint &kpt, float *desc) {
 
-    float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0;
-    float rx = 0.0, ry = 0.0, len = 0.0, xf = 0.0, yf = 0.0;
-    float sample_x = 0.0, sample_y = 0.0;
-    float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
-    int x1 = 0, y1 = 0, x2 = 0, y2 = 0, sample_step = 0, pattern_size = 0, dcount = 0;
-    int scale = 0, dsize = 0, level = 0;
+  float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0;
+  float rx = 0.0, ry = 0.0, len = 0.0, xf = 0.0, yf = 0.0;
+  float sample_x = 0.0, sample_y = 0.0;
+  float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
+  int x1 = 0, y1 = 0, x2 = 0, y2 = 0, sample_step = 0, pattern_size = 0, dcount = 0;
+  int scale = 0, dsize = 0, level = 0;
 
-    // Set the descriptor size and the sample and pattern sizes
-    dsize = 64;
-    sample_step = 5;
-    pattern_size = 10;
+  // Set the descriptor size and the sample and pattern sizes
+  dsize = 64;
+  sample_step = 5;
+  pattern_size = 10;
 
-    // Get the information from the keypoint
-    ratio = (float)(1<<kpt.octave);
-    scale = fRound(0.5*kpt.size/ratio);
-    level = kpt.class_id;
-    yf = kpt.pt.y/ratio;
-    xf = kpt.pt.x/ratio;
+  // Get the information from the keypoint
+  ratio = (float)(1<<kpt.octave);
+  scale = fRound(0.5*kpt.size/ratio);
+  level = kpt.class_id;
+  yf = kpt.pt.y/ratio;
+  xf = kpt.pt.x/ratio;
 
-    // Calculate descriptor for this interest point
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-            dx=dy=mdx=mdy=0.0;
+  // Calculate descriptor for this interest point
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+      dx=dy=mdx=mdy=0.0;
 
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point on the rotated axis
-                    sample_y = yf + l*scale;
-                    sample_x = xf + k*scale;
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point on the rotated axis
+          sample_y = yf + l*scale;
+          sample_x = xf + k*scale;
 
-                    y1 = (int)(sample_y-.5);
-                    x1 = (int)(sample_x-.5);
+          y1 = (int)(sample_y-.5);
+          x1 = (int)(sample_x-.5);
 
-                    y2 = (int)(sample_y+.5);
-                    x2 = (int)(sample_x+.5);
+          y2 = (int)(sample_y+.5);
+          x2 = (int)(sample_x+.5);
 
-                    fx = sample_x-x1;
-                    fy = sample_y-y1;
+          fx = sample_x-x1;
+          fy = sample_y-y1;
 
-                    res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
-                    rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
+          rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
-                    ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
+          ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    // Sum the derivatives to the cumulative descriptor
-                    dx += rx;
-                    dy += ry;
-                    mdx += fabs(rx);
-                    mdy += fabs(ry);
-                }
-            }
-
-            // Add the values to the descriptor vector
-            desc[dcount++] = dx;
-            desc[dcount++] = dy;
-            desc[dcount++] = mdx;
-            desc[dcount++] = mdy;
-
-            // Store the current length^2 of the vector
-            len += dx*dx + dy*dy + mdx*mdx + mdy*mdy;
+          // Sum the derivatives to the cumulative descriptor
+          dx += rx;
+          dy += ry;
+          mdx += fabs(rx);
+          mdy += fabs(ry);
         }
-    }
+      }
 
-    // convert to unit vector
-    len = sqrt(len);
+      // Add the values to the descriptor vector
+      desc[dcount++] = dx;
+      desc[dcount++] = dy;
+      desc[dcount++] = mdx;
+      desc[dcount++] = mdy;
 
-    for (int i = 0; i < dsize; i++) {
-        desc[i] /= len;
+      // Store the current length^2 of the vector
+      len += dx*dx + dy*dy + mdx*mdx + mdy*mdy;
     }
+  }
+
+  // convert to unit vector
+  len = sqrt(len);
+
+  for (int i = 0; i < dsize; i++) {
+    desc[i] /= len;
+  }
 
 }
 
@@ -823,89 +823,89 @@ void AKAZE::Get_SURF_Descriptor_Upright_64(const cv::KeyPoint &kpt, float *desc)
 */
 void AKAZE::Get_SURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc) {
 
-    float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0;
-    float rx = 0.0, ry = 0.0, rrx = 0.0, rry = 0.0, len = 0.0, xf = 0.0, yf = 0.0;
-    float sample_x = 0.0, sample_y = 0.0, co = 0.0, si = 0.0, angle = 0.0;
-    float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
-    int x1 = 0, y1 = 0, x2 = 0, y2 = 0, sample_step = 0, pattern_size = 0, dcount = 0;
-    int scale = 0, dsize = 0, level = 0;
+  float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0;
+  float rx = 0.0, ry = 0.0, rrx = 0.0, rry = 0.0, len = 0.0, xf = 0.0, yf = 0.0;
+  float sample_x = 0.0, sample_y = 0.0, co = 0.0, si = 0.0, angle = 0.0;
+  float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
+  int x1 = 0, y1 = 0, x2 = 0, y2 = 0, sample_step = 0, pattern_size = 0, dcount = 0;
+  int scale = 0, dsize = 0, level = 0;
 
-    // Set the descriptor size and the sample and pattern sizes
-    dsize = 64;
-    sample_step = 5;
-    pattern_size = 10;
+  // Set the descriptor size and the sample and pattern sizes
+  dsize = 64;
+  sample_step = 5;
+  pattern_size = 10;
 
-    // Get the information from the keypoint
-    ratio = (float)(1<<kpt.octave);
-    scale = fRound(0.5*kpt.size/ratio);
-    angle = kpt.angle;
-    level = kpt.class_id;
-    yf = kpt.pt.y/ratio;
-    xf = kpt.pt.x/ratio;
-    co = cos(angle);
-    si = sin(angle);
+  // Get the information from the keypoint
+  ratio = (float)(1<<kpt.octave);
+  scale = fRound(0.5*kpt.size/ratio);
+  angle = kpt.angle;
+  level = kpt.class_id;
+  yf = kpt.pt.y/ratio;
+  xf = kpt.pt.x/ratio;
+  co = cos(angle);
+  si = sin(angle);
 
-    // Calculate descriptor for this interest point
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-            dx=dy=mdx=mdy=0.0;
+  // Calculate descriptor for this interest point
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+      dx=dy=mdx=mdy=0.0;
 
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point on the rotated axis
-                    sample_y = yf + (l*scale*co + k*scale*si);
-                    sample_x = xf + (-l*scale*si + k*scale*co);
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point on the rotated axis
+          sample_y = yf + (l*scale*co + k*scale*si);
+          sample_x = xf + (-l*scale*si + k*scale*co);
 
-                    y1 = (int)(sample_y-.5);
-                    x1 = (int)(sample_x-.5);
+          y1 = (int)(sample_y-.5);
+          x1 = (int)(sample_x-.5);
 
-                    y2 = (int)(sample_y+.5);
-                    x2 = (int)(sample_x+.5);
+          y2 = (int)(sample_y+.5);
+          x2 = (int)(sample_x+.5);
 
-                    fx = sample_x-x1;
-                    fy = sample_y-y1;
+          fx = sample_x-x1;
+          fy = sample_y-y1;
 
-                    res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
-                    rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
+          rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
-                    ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
+          ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    // Get the x and y derivatives on the rotated axis
-                    rry = rx*co + ry*si;
-                    rrx = -rx*si + ry*co;
+          // Get the x and y derivatives on the rotated axis
+          rry = rx*co + ry*si;
+          rrx = -rx*si + ry*co;
 
-                    // Sum the derivatives to the cumulative descriptor
-                    dx += rrx;
-                    dy += rry;
-                    mdx += fabs(rrx);
-                    mdy += fabs(rry);
-                }
-            }
-
-            // Add the values to the descriptor vector
-            desc[dcount++] = dx;
-            desc[dcount++] = dy;
-            desc[dcount++] = mdx;
-            desc[dcount++] = mdy;
-
-            // Store the current length^2 of the vector
-            len += dx*dx + dy*dy + mdx*mdx + mdy*mdy;
+          // Sum the derivatives to the cumulative descriptor
+          dx += rrx;
+          dy += rry;
+          mdx += fabs(rrx);
+          mdy += fabs(rry);
         }
-    }
+      }
 
-    // convert to unit vector
-    len = sqrt(len);
+      // Add the values to the descriptor vector
+      desc[dcount++] = dx;
+      desc[dcount++] = dy;
+      desc[dcount++] = mdx;
+      desc[dcount++] = mdy;
 
-    for (int i = 0; i < dsize; i++) {
-        desc[i] /= len;
+      // Store the current length^2 of the vector
+      len += dx*dx + dy*dy + mdx*mdx + mdy*mdy;
     }
+  }
+
+  // convert to unit vector
+  len = sqrt(len);
+
+  for (int i = 0; i < dsize; i++) {
+    desc[i] /= len;
+  }
 
 }
 
@@ -923,113 +923,113 @@ void AKAZE::Get_SURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc) {
 */
 void AKAZE::Get_MSURF_Upright_Descriptor_64(const cv::KeyPoint &kpt, float *desc) {
 
-    float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0, gauss_s1 = 0.0, gauss_s2 = 0.0;
-    float rx = 0.0, ry = 0.0, len = 0.0, xf = 0.0, yf = 0.0, ys = 0.0, xs = 0.0;
-    float sample_x = 0.0, sample_y = 0.0;
-    int x1 = 0, y1 = 0, sample_step = 0, pattern_size = 0;
-    int x2 = 0, y2 = 0, kx = 0, ky = 0, i = 0, j = 0, dcount = 0;
-    float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
-    int scale = 0, dsize = 0, level = 0;
+  float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0, gauss_s1 = 0.0, gauss_s2 = 0.0;
+  float rx = 0.0, ry = 0.0, len = 0.0, xf = 0.0, yf = 0.0, ys = 0.0, xs = 0.0;
+  float sample_x = 0.0, sample_y = 0.0;
+  int x1 = 0, y1 = 0, sample_step = 0, pattern_size = 0;
+  int x2 = 0, y2 = 0, kx = 0, ky = 0, i = 0, j = 0, dcount = 0;
+  float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
+  int scale = 0, dsize = 0, level = 0;
 
-    // Subregion centers for the 4x4 gaussian weighting
-    float cx = -0.5, cy = 0.5;
+  // Subregion centers for the 4x4 gaussian weighting
+  float cx = -0.5, cy = 0.5;
 
-    // Set the descriptor size and the sample and pattern sizes
-    dsize = 64;
-    sample_step = 5;
-    pattern_size = 12;
+  // Set the descriptor size and the sample and pattern sizes
+  dsize = 64;
+  sample_step = 5;
+  pattern_size = 12;
 
-    // Get the information from the keypoint
-    ratio = (float)(1<<kpt.octave);
-    scale = fRound(0.5*kpt.size/ratio);
-    level = kpt.class_id;
-    yf = kpt.pt.y/ratio;
-    xf = kpt.pt.x/ratio;
+  // Get the information from the keypoint
+  ratio = (float)(1<<kpt.octave);
+  scale = fRound(0.5*kpt.size/ratio);
+  level = kpt.class_id;
+  yf = kpt.pt.y/ratio;
+  xf = kpt.pt.x/ratio;
 
-    i = -8;
+  i = -8;
 
-    // Calculate descriptor for this interest point
-    // Area of size 24 s x 24 s
-    while (i < pattern_size) {
-        j = -8;
-        i = i-4;
+  // Calculate descriptor for this interest point
+  // Area of size 24 s x 24 s
+  while (i < pattern_size) {
+    j = -8;
+    i = i-4;
 
-        cx += 1.0;
-        cy = -0.5;
+    cx += 1.0;
+    cy = -0.5;
 
-        while (j < pattern_size) {
-            dx=dy=mdx=mdy=0.0;
-            cy += 1.0;
-            j = j-4;
+    while (j < pattern_size) {
+      dx=dy=mdx=mdy=0.0;
+      cy += 1.0;
+      j = j-4;
 
-            ky = i + sample_step;
-            kx = j + sample_step;
+      ky = i + sample_step;
+      kx = j + sample_step;
 
-            ys = yf + (ky*scale);
-            xs = xf + (kx*scale);
+      ys = yf + (ky*scale);
+      xs = xf + (kx*scale);
 
-            for (int k = i; k < i+9; k++) {
-                for (int l = j; l < j+9; l++) {
-                    sample_y = k*scale + yf;
-                    sample_x = l*scale + xf;
+      for (int k = i; k < i+9; k++) {
+        for (int l = j; l < j+9; l++) {
+          sample_y = k*scale + yf;
+          sample_x = l*scale + xf;
 
-                    //Get the gaussian weighted x and y responses
-                    gauss_s1 = gaussian(xs-sample_x,ys-sample_y,2.50*scale);
+          //Get the gaussian weighted x and y responses
+          gauss_s1 = gaussian(xs-sample_x,ys-sample_y,2.50*scale);
 
-                    y1 = (int)(sample_y-.5);
-                    x1 = (int)(sample_x-.5);
+          y1 = (int)(sample_y-.5);
+          x1 = (int)(sample_x-.5);
 
-                    y2 = (int)(sample_y+.5);
-                    x2 = (int)(sample_x+.5);
+          y2 = (int)(sample_y+.5);
+          x2 = (int)(sample_x+.5);
 
-                    fx = sample_x-x1;
-                    fy = sample_y-y1;
+          fx = sample_x-x1;
+          fy = sample_y-y1;
 
-                    res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
-                    rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
+          rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
-                    ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
+          ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    rx = gauss_s1*rx;
-                    ry = gauss_s1*ry;
+          rx = gauss_s1*rx;
+          ry = gauss_s1*ry;
 
-                    // Sum the derivatives to the cumulative descriptor
-                    dx += rx;
-                    dy += ry;
-                    mdx += fabs(rx);
-                    mdy += fabs(ry);
-                }
-            }
-
-            // Add the values to the descriptor vector
-            gauss_s2 = gaussian(cx-2.0f,cy-2.0f,1.5f);
-
-            desc[dcount++] = dx*gauss_s2;
-            desc[dcount++] = dy*gauss_s2;
-            desc[dcount++] = mdx*gauss_s2;
-            desc[dcount++] = mdy*gauss_s2;
-
-            len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy)*gauss_s2*gauss_s2;
-
-            j += 9;
+          // Sum the derivatives to the cumulative descriptor
+          dx += rx;
+          dy += ry;
+          mdx += fabs(rx);
+          mdy += fabs(ry);
         }
+      }
 
-        i += 9;
+      // Add the values to the descriptor vector
+      gauss_s2 = gaussian(cx-2.0f,cy-2.0f,1.5f);
+
+      desc[dcount++] = dx*gauss_s2;
+      desc[dcount++] = dy*gauss_s2;
+      desc[dcount++] = mdx*gauss_s2;
+      desc[dcount++] = mdy*gauss_s2;
+
+      len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy)*gauss_s2*gauss_s2;
+
+      j += 9;
     }
 
-    // convert to unit vector
-    len = sqrt(len);
+    i += 9;
+  }
 
-    for (int i = 0; i < dsize; i++) {
-        desc[i] /= len;
-    }
+  // convert to unit vector
+  len = sqrt(len);
+
+  for (int i = 0; i < dsize; i++) {
+    desc[i] /= len;
+  }
 }
 
 //*************************************************************************************
@@ -1046,117 +1046,117 @@ void AKAZE::Get_MSURF_Upright_Descriptor_64(const cv::KeyPoint &kpt, float *desc
 */
 void AKAZE::Get_MSURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc) {
 
-    float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0, gauss_s1 = 0.0, gauss_s2 = 0.0;
-    float rx = 0.0, ry = 0.0, rrx = 0.0, rry = 0.0, len = 0.0, xf = 0.0, yf = 0.0, ys = 0.0, xs = 0.0;
-    float sample_x = 0.0, sample_y = 0.0, co = 0.0, si = 0.0, angle = 0.0;
-    float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
-    int x1 = 0, y1 = 0, x2 = 0, y2 = 0, sample_step = 0, pattern_size = 0;
-    int kx = 0, ky = 0, i = 0, j = 0, dcount = 0;
-    int scale = 0, dsize = 0, level = 0;
+  float dx = 0.0, dy = 0.0, mdx = 0.0, mdy = 0.0, gauss_s1 = 0.0, gauss_s2 = 0.0;
+  float rx = 0.0, ry = 0.0, rrx = 0.0, rry = 0.0, len = 0.0, xf = 0.0, yf = 0.0, ys = 0.0, xs = 0.0;
+  float sample_x = 0.0, sample_y = 0.0, co = 0.0, si = 0.0, angle = 0.0;
+  float fx = 0.0, fy = 0.0, ratio = 0.0, res1 = 0.0, res2 = 0.0, res3 = 0.0, res4 = 0.0;
+  int x1 = 0, y1 = 0, x2 = 0, y2 = 0, sample_step = 0, pattern_size = 0;
+  int kx = 0, ky = 0, i = 0, j = 0, dcount = 0;
+  int scale = 0, dsize = 0, level = 0;
 
-    // Subregion centers for the 4x4 gaussian weighting
-    float cx = -0.5, cy = 0.5;
+  // Subregion centers for the 4x4 gaussian weighting
+  float cx = -0.5, cy = 0.5;
 
-    // Set the descriptor size and the sample and pattern sizes
-    dsize = 64;
-    sample_step = 5;
-    pattern_size = 12;
+  // Set the descriptor size and the sample and pattern sizes
+  dsize = 64;
+  sample_step = 5;
+  pattern_size = 12;
 
-    // Get the information from the keypoint
-    ratio = (float)(1<<kpt.octave);
-    scale = fRound(0.5*kpt.size/ratio);
-    angle = kpt.angle;
-    level = kpt.class_id;
-    yf = kpt.pt.y/ratio;
-    xf = kpt.pt.x/ratio;
-    co = cos(angle);
-    si = sin(angle);
+  // Get the information from the keypoint
+  ratio = (float)(1<<kpt.octave);
+  scale = fRound(0.5*kpt.size/ratio);
+  angle = kpt.angle;
+  level = kpt.class_id;
+  yf = kpt.pt.y/ratio;
+  xf = kpt.pt.x/ratio;
+  co = cos(angle);
+  si = sin(angle);
 
-    i = -8;
+  i = -8;
 
-    // Calculate descriptor for this interest point
-    // Area of size 24 s x 24 s
-    while (i < pattern_size) {
-        j = -8;
-        i = i-4;
+  // Calculate descriptor for this interest point
+  // Area of size 24 s x 24 s
+  while (i < pattern_size) {
+    j = -8;
+    i = i-4;
 
-        cx += 1.0;
-        cy = -0.5;
+    cx += 1.0;
+    cy = -0.5;
 
-        while (j < pattern_size) {
-            dx=dy=mdx=mdy=0.0;
-            cy += 1.0;
-            j = j - 4;
+    while (j < pattern_size) {
+      dx=dy=mdx=mdy=0.0;
+      cy += 1.0;
+      j = j - 4;
 
-            ky = i + sample_step;
-            kx = j + sample_step;
+      ky = i + sample_step;
+      kx = j + sample_step;
 
-            xs = xf + (-kx*scale*si + ky*scale*co);
-            ys = yf + (kx*scale*co + ky*scale*si);
+      xs = xf + (-kx*scale*si + ky*scale*co);
+      ys = yf + (kx*scale*co + ky*scale*si);
 
-            for (int k = i; k < i + 9; ++k) {
-                for (int l = j; l < j + 9; ++l) {
-                    // Get coords of sample point on the rotated axis
-                    sample_y = yf + (l*scale*co + k*scale*si);
-                    sample_x = xf + (-l*scale*si + k*scale*co);
+      for (int k = i; k < i + 9; ++k) {
+        for (int l = j; l < j + 9; ++l) {
+          // Get coords of sample point on the rotated axis
+          sample_y = yf + (l*scale*co + k*scale*si);
+          sample_x = xf + (-l*scale*si + k*scale*co);
 
-                    // Get the gaussian weighted x and y responses
-                    gauss_s1 = gaussian(xs-sample_x,ys-sample_y,2.5*scale);
+          // Get the gaussian weighted x and y responses
+          gauss_s1 = gaussian(xs-sample_x,ys-sample_y,2.5*scale);
 
-                    y1 = fRound(sample_y-.5);
-                    x1 = fRound(sample_x-.5);
+          y1 = fRound(sample_y-.5);
+          x1 = fRound(sample_x-.5);
 
-                    y2 = fRound(sample_y+.5);
-                    x2 = fRound(sample_x+.5);
+          y2 = fRound(sample_y+.5);
+          x2 = fRound(sample_x+.5);
 
-                    fx = sample_x-x1;
-                    fy = sample_y-y1;
+          fx = sample_x-x1;
+          fy = sample_y-y1;
 
-                    res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
-                    rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Lx.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Lx.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Lx.ptr<float>(y2)+x2);
+          rx = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-                    res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
-                    res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
-                    res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
-                    ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
+          res1 = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          res2 = *(evolution_[level].Ly.ptr<float>(y1)+x2);
+          res3 = *(evolution_[level].Ly.ptr<float>(y2)+x1);
+          res4 = *(evolution_[level].Ly.ptr<float>(y2)+x2);
+          ry = (1.0-fx)*(1.0-fy)*res1 + fx*(1.0-fy)*res2 + (1.0-fx)*fy*res3 + fx*fy*res4;
 
-                    // Get the x and y derivatives on the rotated axis
-                    rry = gauss_s1*(rx*co + ry*si);
-                    rrx = gauss_s1*(-rx*si + ry*co);
+          // Get the x and y derivatives on the rotated axis
+          rry = gauss_s1*(rx*co + ry*si);
+          rrx = gauss_s1*(-rx*si + ry*co);
 
-                    // Sum the derivatives to the cumulative descriptor
-                    dx += rrx;
-                    dy += rry;
-                    mdx += fabs(rrx);
-                    mdy += fabs(rry);
-                }
-            }
-
-            // Add the values to the descriptor vector
-            gauss_s2 = gaussian(cx-2.0f,cy-2.0f,1.5f);
-            desc[dcount++] = dx*gauss_s2;
-            desc[dcount++] = dy*gauss_s2;
-            desc[dcount++] = mdx*gauss_s2;
-            desc[dcount++] = mdy*gauss_s2;
-
-            len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy)*gauss_s2*gauss_s2;
-
-            j += 9;
+          // Sum the derivatives to the cumulative descriptor
+          dx += rrx;
+          dy += rry;
+          mdx += fabs(rrx);
+          mdy += fabs(rry);
         }
+      }
 
-        i += 9;
+      // Add the values to the descriptor vector
+      gauss_s2 = gaussian(cx-2.0f,cy-2.0f,1.5f);
+      desc[dcount++] = dx*gauss_s2;
+      desc[dcount++] = dy*gauss_s2;
+      desc[dcount++] = mdx*gauss_s2;
+      desc[dcount++] = mdy*gauss_s2;
+
+      len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy)*gauss_s2*gauss_s2;
+
+      j += 9;
     }
 
-    // convert to unit vector
-    len = sqrt(len);
+    i += 9;
+  }
 
-    for (int i = 0; i < dsize; i++) {
-        desc[i] /= len;
-    }
+  // convert to unit vector
+  len = sqrt(len);
+
+  for (int i = 0; i < dsize; i++) {
+    desc[i] /= len;
+  }
 }
 
 //*************************************************************************************
@@ -1170,206 +1170,206 @@ void AKAZE::Get_MSURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc) {
 */
 void AKAZE::Get_Upright_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *desc) {
 
-    float di = 0.0, dx = 0.0, dy = 0.0;
-    float ri = 0.0, rx = 0.0, ry = 0.0, xf = 0.0, yf = 0.0;
-    float sample_x = 0.0, sample_y = 0.0, ratio = 0.0;
-    int x1 = 0, y1 = 0, sample_step = 0, pattern_size = 0;
-    int level = 0, nsamples = 0, scale = 0;
-    int dcount1 = 0, dcount2 = 0;
+  float di = 0.0, dx = 0.0, dy = 0.0;
+  float ri = 0.0, rx = 0.0, ry = 0.0, xf = 0.0, yf = 0.0;
+  float sample_x = 0.0, sample_y = 0.0, ratio = 0.0;
+  int x1 = 0, y1 = 0, sample_step = 0, pattern_size = 0;
+  int level = 0, nsamples = 0, scale = 0;
+  int dcount1 = 0, dcount2 = 0;
 
-    // Matrices for the LDB descriptor
-    Mat values_1 = cv::Mat::zeros(4,descriptor_channels_,CV_32FC1);
-    Mat values_2 = cv::Mat::zeros(9,descriptor_channels_,CV_32FC1);
-    Mat values_3 = cv::Mat::zeros(16,descriptor_channels_,CV_32FC1);
+  // Matrices for the LDB descriptor
+  Mat values_1 = cv::Mat::zeros(4,descriptor_channels_,CV_32FC1);
+  Mat values_2 = cv::Mat::zeros(9,descriptor_channels_,CV_32FC1);
+  Mat values_3 = cv::Mat::zeros(16,descriptor_channels_,CV_32FC1);
 
-    // Get the information from the keypoint
-    ratio = (float)(1<<kpt.octave);
-    scale = fRound(0.5*kpt.size/ratio);
-    level = kpt.class_id;
-    yf = kpt.pt.y/ratio;
-    xf = kpt.pt.x/ratio;
+  // Get the information from the keypoint
+  ratio = (float)(1<<kpt.octave);
+  scale = fRound(0.5*kpt.size/ratio);
+  level = kpt.class_id;
+  yf = kpt.pt.y/ratio;
+  xf = kpt.pt.x/ratio;
 
-    // First 2x2 grid
-    pattern_size = descriptor_pattern_size_;
-    sample_step = pattern_size;
+  // First 2x2 grid
+  pattern_size = descriptor_pattern_size_;
+  sample_step = pattern_size;
 
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-            di=dx=dy=0.0;
-            nsamples = 0;
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+      di=dx=dy=0.0;
+      nsamples = 0;
 
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point
-                    sample_y = yf + l*scale;
-                    sample_x = xf + k*scale;
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point
+          sample_y = yf + l*scale;
+          sample_x = xf + k*scale;
 
-                    y1 = fRound(sample_y);
-                    x1 = fRound(sample_x);
+          y1 = fRound(sample_y);
+          x1 = fRound(sample_x);
 
-                    ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
 
-                    di += ri;
-                    dx += rx;
-                    dy += ry;
-                    nsamples++;
-                }
-            }
-
-            di /= nsamples;
-            dx /= nsamples;
-            dy /= nsamples;
-
-            *(values_1.ptr<float>(dcount2)) = di;
-            *(values_1.ptr<float>(dcount2)+1) = dx;
-            *(values_1.ptr<float>(dcount2)+2) = dy;
-            dcount2++;
+          di += ri;
+          dx += rx;
+          dy += ry;
+          nsamples++;
         }
+      }
+
+      di /= nsamples;
+      dx /= nsamples;
+      dy /= nsamples;
+
+      *(values_1.ptr<float>(dcount2)) = di;
+      *(values_1.ptr<float>(dcount2)+1) = dx;
+      *(values_1.ptr<float>(dcount2)+2) = dy;
+      dcount2++;
     }
+  }
 
-    // Do binary comparison first level
-    for(int i = 0; i < 4; i++) {
-        for (int j = i+1; j < 4; j++) {
-            if (*(values_1.ptr<float>(i)) > *(values_1.ptr<float>(j))) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+  // Do binary comparison first level
+  for(int i = 0; i < 4; i++) {
+    for (int j = i+1; j < 4; j++) {
+      if (*(values_1.ptr<float>(i)) > *(values_1.ptr<float>(j))) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
 
-            if (*(values_1.ptr<float>(i)+1) > *(values_1.ptr<float>(j)+1)) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+      if (*(values_1.ptr<float>(i)+1) > *(values_1.ptr<float>(j)+1)) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
 
-            if (*(values_1.ptr<float>(i)+2) > *(values_1.ptr<float>(j)+2)) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+      if (*(values_1.ptr<float>(i)+2) > *(values_1.ptr<float>(j)+2)) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
+    }
+  }
+
+  // Second 3x3 grid
+  sample_step = ceil(pattern_size*2./3.);
+  dcount2 = 0;
+
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+      di=dx=dy=0.0;
+      nsamples = 0;
+
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point
+          sample_y = yf + l*scale;
+          sample_x = xf + k*scale;
+
+          y1 = fRound(sample_y);
+          x1 = fRound(sample_x);
+
+          ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+
+          di += ri;
+          dx += rx;
+          dy += ry;
+          nsamples++;
         }
+      }
+
+      di /= nsamples;
+      dx /= nsamples;
+      dy /= nsamples;
+
+      *(values_2.ptr<float>(dcount2)) = di;
+      *(values_2.ptr<float>(dcount2)+1) = dx;
+      *(values_2.ptr<float>(dcount2)+2) = dy;
+      dcount2++;
     }
+  }
 
-    // Second 3x3 grid
-    sample_step = ceil(pattern_size*2./3.);
-    dcount2 = 0;
+  dcount2 = 0;
+  //Do binary comparison second level
+  for (int i = 0; i < 9; i++) {
+    for (int j = i+1; j < 9; j++) {
+      if (*(values_2.ptr<float>(i)) > *(values_2.ptr<float>(j))) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
 
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-            di=dx=dy=0.0;
-            nsamples = 0;
+      if (*(values_2.ptr<float>(i)+1) > *(values_2.ptr<float>(j)+1)) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
 
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point
-                    sample_y = yf + l*scale;
-                    sample_x = xf + k*scale;
+      if(*(values_2.ptr<float>(i)+2) > *(values_2.ptr<float>(j)+2)) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
+    }
+  }
 
-                    y1 = fRound(sample_y);
-                    x1 = fRound(sample_x);
+  // Third 4x4 grid
+  sample_step = pattern_size/2;
+  dcount2 = 0;
 
-                    ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+      di=dx=dy=0.0;
+      nsamples = 0;
 
-                    di += ri;
-                    dx += rx;
-                    dy += ry;
-                    nsamples++;
-                }
-            }
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point
+          sample_y = yf + l*scale;
+          sample_x = xf + k*scale;
 
-            di /= nsamples;
-            dx /= nsamples;
-            dy /= nsamples;
+          y1 = fRound(sample_y);
+          x1 = fRound(sample_x);
 
-            *(values_2.ptr<float>(dcount2)) = di;
-            *(values_2.ptr<float>(dcount2)+1) = dx;
-            *(values_2.ptr<float>(dcount2)+2) = dy;
-            dcount2++;
+          ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+
+          di += ri;
+          dx += rx;
+          dy += ry;
+          nsamples++;
         }
+      }
+
+      di /= nsamples;
+      dx /= nsamples;
+      dy /= nsamples;
+
+      *(values_3.ptr<float>(dcount2)) = di;
+      *(values_3.ptr<float>(dcount2)+1) = dx;
+      *(values_3.ptr<float>(dcount2)+2) = dy;
+      dcount2++;
     }
+  }
 
-    dcount2 = 0;
-    //Do binary comparison second level
-    for (int i = 0; i < 9; i++) {
-        for (int j = i+1; j < 9; j++) {
-            if (*(values_2.ptr<float>(i)) > *(values_2.ptr<float>(j))) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+  dcount2 = 0;
+  //Do binary comparison third level
+  for (int i = 0; i < 16; i++) {
+    for (int j = i+1; j < 16; j++) {
+      if (*(values_3.ptr<float>(i)) > *(values_3.ptr<float>(j))) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
 
-            if (*(values_2.ptr<float>(i)+1) > *(values_2.ptr<float>(j)+1)) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+      if (*(values_3.ptr<float>(i)+1) > *(values_3.ptr<float>(j)+1)) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
 
-            if(*(values_2.ptr<float>(i)+2) > *(values_2.ptr<float>(j)+2)) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
-        }
+      if (*(values_3.ptr<float>(i)+2) > *(values_3.ptr<float>(j)+2)) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
     }
-
-    // Third 4x4 grid
-    sample_step = pattern_size/2;
-    dcount2 = 0;
-
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-            di=dx=dy=0.0;
-            nsamples = 0;
-
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point
-                    sample_y = yf + l*scale;
-                    sample_x = xf + k*scale;
-
-                    y1 = fRound(sample_y);
-                    x1 = fRound(sample_x);
-
-                    ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-
-                    di += ri;
-                    dx += rx;
-                    dy += ry;
-                    nsamples++;
-                }
-            }
-
-            di /= nsamples;
-            dx /= nsamples;
-            dy /= nsamples;
-
-            *(values_3.ptr<float>(dcount2)) = di;
-            *(values_3.ptr<float>(dcount2)+1) = dx;
-            *(values_3.ptr<float>(dcount2)+2) = dy;
-            dcount2++;
-        }
-    }
-
-    dcount2 = 0;
-    //Do binary comparison third level
-    for (int i = 0; i < 16; i++) {
-        for (int j = i+1; j < 16; j++) {
-            if (*(values_3.ptr<float>(i)) > *(values_3.ptr<float>(j))) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
-
-            if (*(values_3.ptr<float>(i)+1) > *(values_3.ptr<float>(j)+1)) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
-
-            if (*(values_3.ptr<float>(i)+2) > *(values_3.ptr<float>(j)+2)) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
-        }
-    }
+  }
 }
 
 //*************************************************************************************
@@ -1383,294 +1383,294 @@ void AKAZE::Get_Upright_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned c
 */
 void AKAZE::Get_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *desc) {
 
-    float di = 0.0, dx = 0.0, dy = 0.0, ratio = 0.0;
-    float ri = 0.0, rx = 0.0, ry = 0.0, rrx = 0.0, rry = 0.0, xf = 0.0, yf = 0.0;
-    float sample_x = 0.0, sample_y = 0.0, co = 0.0, si = 0.0, angle = 0.0;
-    int x1 = 0, y1 = 0, sample_step = 0, pattern_size = 0;
-    int level = 0, nsamples = 0, scale = 0;
-    int dcount1 = 0, dcount2 = 0;
+  float di = 0.0, dx = 0.0, dy = 0.0, ratio = 0.0;
+  float ri = 0.0, rx = 0.0, ry = 0.0, rrx = 0.0, rry = 0.0, xf = 0.0, yf = 0.0;
+  float sample_x = 0.0, sample_y = 0.0, co = 0.0, si = 0.0, angle = 0.0;
+  int x1 = 0, y1 = 0, sample_step = 0, pattern_size = 0;
+  int level = 0, nsamples = 0, scale = 0;
+  int dcount1 = 0, dcount2 = 0;
 
-    // Matrices for the LDB descriptor
-    Mat values_1 = Mat::zeros(4,descriptor_channels_,CV_32FC1);
-    Mat values_2 = Mat::zeros(9,descriptor_channels_,CV_32FC1);
-    Mat values_3 = Mat::zeros(16,descriptor_channels_,CV_32FC1);
+  // Matrices for the LDB descriptor
+  Mat values_1 = Mat::zeros(4,descriptor_channels_,CV_32FC1);
+  Mat values_2 = Mat::zeros(9,descriptor_channels_,CV_32FC1);
+  Mat values_3 = Mat::zeros(16,descriptor_channels_,CV_32FC1);
 
-    // Get the information from the keypoint
-    ratio = (float)(1<<kpt.octave);
-    scale = fRound(0.5*kpt.size/ratio);
-    angle = kpt.angle;
-    level = kpt.class_id;
-    yf = kpt.pt.y/ratio;
-    xf = kpt.pt.x/ratio;
-    co = cos(angle);
-    si = sin(angle);
+  // Get the information from the keypoint
+  ratio = (float)(1<<kpt.octave);
+  scale = fRound(0.5*kpt.size/ratio);
+  angle = kpt.angle;
+  level = kpt.class_id;
+  yf = kpt.pt.y/ratio;
+  xf = kpt.pt.x/ratio;
+  co = cos(angle);
+  si = sin(angle);
 
-    // First 2x2 grid
-    pattern_size = descriptor_pattern_size_;
-    sample_step = pattern_size;
+  // First 2x2 grid
+  pattern_size = descriptor_pattern_size_;
+  sample_step = pattern_size;
 
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
 
-            di=dx=dy=0.0;
-            nsamples = 0;
+      di=dx=dy=0.0;
+      nsamples = 0;
 
-            for (float k = i; k < i + sample_step; k++) {
-                for (float l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point
-                    sample_y = yf + (l*scale*co + k*scale*si);
-                    sample_x = xf + (-l*scale*si + k*scale*co);
+      for (float k = i; k < i + sample_step; k++) {
+        for (float l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point
+          sample_y = yf + (l*scale*co + k*scale*si);
+          sample_x = xf + (-l*scale*si + k*scale*co);
 
-                    y1 = fRound(sample_y);
-                    x1 = fRound(sample_x);
+          y1 = fRound(sample_y);
+          x1 = fRound(sample_x);
 
-                    ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
 
-                    di += ri;
+          di += ri;
 
-                    if (descriptor_channels_ == 2) {
-                        dx += sqrtf(rx*rx + ry*ry);
-                    }
-                    else if (descriptor_channels_ == 3) {
-                        // Get the x and y derivatives on the rotated axis
-                        rry = rx*co + ry*si;
-                        rrx = -rx*si + ry*co;
-                        dx += rrx;
-                        dy += rry;
-                    }
+          if (descriptor_channels_ == 2) {
+            dx += sqrtf(rx*rx + ry*ry);
+          }
+          else if (descriptor_channels_ == 3) {
+            // Get the x and y derivatives on the rotated axis
+            rry = rx*co + ry*si;
+            rrx = -rx*si + ry*co;
+            dx += rrx;
+            dy += rry;
+          }
 
-                    nsamples++;
-                }
-            }
-
-            di /= nsamples;
-            dx /= nsamples;
-            dy /= nsamples;
-
-            *(values_1.ptr<float>(dcount2)) = di;
-            if ( descriptor_channels_ > 1 ) {
-                *(values_1.ptr<float>(dcount2)+1) = dx;
-            }
-
-            if ( descriptor_channels_ > 2 ) {
-                *(values_1.ptr<float>(dcount2)+2) = dy;
-            }
-
-            dcount2++;
+          nsamples++;
         }
-    }
+      }
 
-    // Do binary comparison first level
+      di /= nsamples;
+      dx /= nsamples;
+      dy /= nsamples;
+
+      *(values_1.ptr<float>(dcount2)) = di;
+      if ( descriptor_channels_ > 1 ) {
+        *(values_1.ptr<float>(dcount2)+1) = dx;
+      }
+
+      if ( descriptor_channels_ > 2 ) {
+        *(values_1.ptr<float>(dcount2)+2) = dy;
+      }
+
+      dcount2++;
+    }
+  }
+
+  // Do binary comparison first level
+  for (int i = 0; i < 4; i++) {
+    for (int j = i+1; j < 4; j++) {
+      if (*(values_1.ptr<float>(i)) > *(values_1.ptr<float>(j))) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
+    }
+  }
+
+  if (descriptor_channels_ > 1) {
     for (int i = 0; i < 4; i++) {
-        for (int j = i+1; j < 4; j++) {
-            if (*(values_1.ptr<float>(i)) > *(values_1.ptr<float>(j))) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+      for (int j = i+1; j < 4; j++) {
+        if (*(values_1.ptr<float>(i)+1) > *(values_1.ptr<float>(j)+1)) {
+          desc[dcount1/8] |= (1<<(dcount1%8));
         }
+
+        dcount1++;
+      }
     }
+  }
 
-    if (descriptor_channels_ > 1) {
-        for (int i = 0; i < 4; i++) {
-            for (int j = i+1; j < 4; j++) {
-                if (*(values_1.ptr<float>(i)+1) > *(values_1.ptr<float>(j)+1)) {
-                    desc[dcount1/8] |= (1<<(dcount1%8));
-                }
-
-                dcount1++;
-            }
+  if (descriptor_channels_ > 2) {
+    for (int i = 0; i < 4; i++) {
+      for ( int j = i+1; j < 4; j++) {
+        if (*(values_1.ptr<float>(i)+2) > *(values_1.ptr<float>(j)+2)) {
+          desc[dcount1/8] |= (1<<(dcount1%8));
         }
+        dcount1++;
+      }
     }
+  }
 
-    if (descriptor_channels_ > 2) {
-        for (int i = 0; i < 4; i++) {
-            for ( int j = i+1; j < 4; j++) {
-                if (*(values_1.ptr<float>(i)+2) > *(values_1.ptr<float>(j)+2)) {
-                    desc[dcount1/8] |= (1<<(dcount1%8));
-                }
-                dcount1++;
-            }
+  // Second 3x3 grid
+  sample_step = ceil(pattern_size*2./3.);
+  dcount2 = 0;
+
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+
+      di=dx=dy=0.0;
+      nsamples = 0;
+
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+
+          // Get the coordinates of the sample point
+          sample_y = yf + (l*scale*co + k*scale*si);
+          sample_x = xf + (-l*scale*si + k*scale*co);
+
+          y1 = fRound(sample_y);
+          x1 = fRound(sample_x);
+
+          ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          di += ri;
+
+          if (descriptor_channels_ == 2) {
+            dx += sqrtf(rx*rx + ry*ry);
+          }
+          else if (descriptor_channels_ == 3) {
+            // Get the x and y derivatives on the rotated axis
+            rry = rx*co + ry*si;
+            rrx = -rx*si + ry*co;
+            dx += rrx;
+            dy += rry;
+          }
+
+          nsamples++;
         }
+      }
+
+      di /= nsamples;
+      dx /= nsamples;
+      dy /= nsamples;
+
+      *(values_2.ptr<float>(dcount2)) = di;
+      if (descriptor_channels_ > 1) {
+        *(values_2.ptr<float>(dcount2)+1) = dx;
+      }
+
+      if (descriptor_channels_ > 2) {
+        *(values_2.ptr<float>(dcount2)+2) = dy;
+      }
+
+      dcount2++;
     }
+  }
 
-    // Second 3x3 grid
-    sample_step = ceil(pattern_size*2./3.);
-    dcount2 = 0;
-
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-
-            di=dx=dy=0.0;
-            nsamples = 0;
-
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-
-                    // Get the coordinates of the sample point
-                    sample_y = yf + (l*scale*co + k*scale*si);
-                    sample_x = xf + (-l*scale*si + k*scale*co);
-
-                    y1 = fRound(sample_y);
-                    x1 = fRound(sample_x);
-
-                    ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-                    di += ri;
-
-                    if (descriptor_channels_ == 2) {
-                        dx += sqrtf(rx*rx + ry*ry);
-                    }
-                    else if (descriptor_channels_ == 3) {
-                        // Get the x and y derivatives on the rotated axis
-                        rry = rx*co + ry*si;
-                        rrx = -rx*si + ry*co;
-                        dx += rrx;
-                        dy += rry;
-                    }
-
-                    nsamples++;
-                }
-            }
-
-            di /= nsamples;
-            dx /= nsamples;
-            dy /= nsamples;
-
-            *(values_2.ptr<float>(dcount2)) = di;
-            if (descriptor_channels_ > 1) {
-                *(values_2.ptr<float>(dcount2)+1) = dx;
-            }
-
-            if (descriptor_channels_ > 2) {
-                *(values_2.ptr<float>(dcount2)+2) = dy;
-            }
-
-            dcount2++;
-        }
+  // Do binary comparison second level
+  for (int i = 0; i < 9; i++) {
+    for (int j = i+1; j < 9; j++) {
+      if (*(values_2.ptr<float>(i)) > *(values_2.ptr<float>(j))) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
     }
+  }
 
-    // Do binary comparison second level
+  if (descriptor_channels_ > 1) {
     for (int i = 0; i < 9; i++) {
-        for (int j = i+1; j < 9; j++) {
-            if (*(values_2.ptr<float>(i)) > *(values_2.ptr<float>(j))) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+      for (int j = i+1; j < 9; j++) {
+        if (*(values_2.ptr<float>(i)+1) > *(values_2.ptr<float>(j)+1)) {
+          desc[dcount1/8] |= (1<<(dcount1%8));
         }
+        dcount1++;
+      }
     }
+  }
 
-    if (descriptor_channels_ > 1) {
-        for (int i = 0; i < 9; i++) {
-            for (int j = i+1; j < 9; j++) {
-                if (*(values_2.ptr<float>(i)+1) > *(values_2.ptr<float>(j)+1)) {
-                    desc[dcount1/8] |= (1<<(dcount1%8));
-                }
-                dcount1++;
-            }
+  if (descriptor_channels_ > 2) {
+    for (int i = 0; i < 9; i++) {
+      for (int j = i+1; j < 9; j++) {
+        if (*(values_2.ptr<float>(i)+2) > *(values_2.ptr<float>(j)+2)) {
+          desc[dcount1/8] |= (1<<(dcount1%8));
         }
+        dcount1++;
+      }
     }
+  }
 
-    if (descriptor_channels_ > 2) {
-        for (int i = 0; i < 9; i++) {
-            for (int j = i+1; j < 9; j++) {
-                if (*(values_2.ptr<float>(i)+2) > *(values_2.ptr<float>(j)+2)) {
-                    desc[dcount1/8] |= (1<<(dcount1%8));
-                }
-                dcount1++;
-            }
+  // Third 4x4 grid
+  sample_step = pattern_size/2;
+  dcount2 = 0;
+
+  for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
+    for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
+      di=dx=dy=0.0;
+      nsamples = 0;
+
+      for (int k = i; k < i + sample_step; k++) {
+        for (int l = j; l < j + sample_step; l++) {
+          // Get the coordinates of the sample point
+          sample_y = yf + (l*scale*co + k*scale*si);
+          sample_x = xf + (-l*scale*si + k*scale*co);
+
+          y1 = fRound(sample_y);
+          x1 = fRound(sample_x);
+
+          ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+          di += ri;
+
+          if (descriptor_channels_ == 2) {
+            dx += sqrtf(rx*rx + ry*ry);
+          }
+          else if (descriptor_channels_ == 3) {
+            // Get the x and y derivatives on the rotated axis
+            rry = rx*co + ry*si;
+            rrx = -rx*si + ry*co;
+            dx += rrx;
+            dy += rry;
+          }
+
+          nsamples++;
         }
+      }
+
+      di /= nsamples;
+      dx /= nsamples;
+      dy /= nsamples;
+
+      *(values_3.ptr<float>(dcount2)) = di;
+      if (descriptor_channels_ > 1) {
+        *(values_3.ptr<float>(dcount2)+1) = dx;
+      }
+
+      if (descriptor_channels_ > 2) {
+        *(values_3.ptr<float>(dcount2)+2) = dy;
+      }
+
+      dcount2++;
     }
+  }
 
-    // Third 4x4 grid
-    sample_step = pattern_size/2;
-    dcount2 = 0;
+  // Do binary comparison third level
+  for(int i = 0; i < 16; i++) {
+    for(int j = i+1; j < 16; j++) {
+      if (*(values_3.ptr<float>(i)) > *(values_3.ptr<float>(j))) {
+        desc[dcount1/8] |= (1<<(dcount1%8));
+      }
+      dcount1++;
+    }
+  }
 
-    for (int i = -pattern_size; i < pattern_size; i+=sample_step) {
-        for (int j = -pattern_size; j < pattern_size; j+=sample_step) {
-            di=dx=dy=0.0;
-            nsamples = 0;
-
-            for (int k = i; k < i + sample_step; k++) {
-                for (int l = j; l < j + sample_step; l++) {
-                    // Get the coordinates of the sample point
-                    sample_y = yf + (l*scale*co + k*scale*si);
-                    sample_x = xf + (-l*scale*si + k*scale*co);
-
-                    y1 = fRound(sample_y);
-                    x1 = fRound(sample_x);
-
-                    ri = *(evolution_[level].Lt.ptr<float>(y1)+x1);
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
-                    di += ri;
-
-                    if (descriptor_channels_ == 2) {
-                        dx += sqrtf(rx*rx + ry*ry);
-                    }
-                    else if (descriptor_channels_ == 3) {
-                        // Get the x and y derivatives on the rotated axis
-                        rry = rx*co + ry*si;
-                        rrx = -rx*si + ry*co;
-                        dx += rrx;
-                        dy += rry;
-                    }
-
-                    nsamples++;
-                }
-            }
-
-            di /= nsamples;
-            dx /= nsamples;
-            dy /= nsamples;
-
-            *(values_3.ptr<float>(dcount2)) = di;
-            if (descriptor_channels_ > 1) {
-                *(values_3.ptr<float>(dcount2)+1) = dx;
-            }
-
-            if (descriptor_channels_ > 2) {
-                *(values_3.ptr<float>(dcount2)+2) = dy;
-            }
-
-            dcount2++;
+  if (descriptor_channels_ > 1) {
+    for (int i = 0; i < 16; i++) {
+      for (int j = i+1; j < 16; j++) {
+        if (*(values_3.ptr<float>(i)+1) > *(values_3.ptr<float>(j)+1)) {
+          desc[dcount1/8] |= (1<<(dcount1%8));
         }
+        dcount1++;
+      }
     }
+  }
 
-    // Do binary comparison third level
-    for(int i = 0; i < 16; i++) {
-        for(int j = i+1; j < 16; j++) {
-            if (*(values_3.ptr<float>(i)) > *(values_3.ptr<float>(j))) {
-                desc[dcount1/8] |= (1<<(dcount1%8));
-            }
-            dcount1++;
+  if (descriptor_channels_ > 2)
+  {
+    for (int i = 0; i < 16; i++) {
+      for (int j = i+1; j < 16; j++) {
+        if (*(values_3.ptr<float>(i)+2) > *(values_3.ptr<float>(j)+2)) {
+          desc[dcount1/8] |= (1<<(dcount1%8));
         }
+        dcount1++;
+      }
     }
-
-    if (descriptor_channels_ > 1) {
-        for (int i = 0; i < 16; i++) {
-            for (int j = i+1; j < 16; j++) {
-                if (*(values_3.ptr<float>(i)+1) > *(values_3.ptr<float>(j)+1)) {
-                    desc[dcount1/8] |= (1<<(dcount1%8));
-                }
-                dcount1++;
-            }
-        }
-    }
-
-    if (descriptor_channels_ > 2)
-    {
-        for (int i = 0; i < 16; i++) {
-            for (int j = i+1; j < 16; j++) {
-                if (*(values_3.ptr<float>(i)+2) > *(values_3.ptr<float>(j)+2)) {
-                    desc[dcount1/8] |= (1<<(dcount1%8));
-                }
-                dcount1++;
-            }
-        }
-    }
+  }
 }
 
 //*************************************************************************************
@@ -1685,84 +1685,84 @@ void AKAZE::Get_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *des
 */
 void AKAZE::Get_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *desc) {
 
-    float di, dx, dy;
-    float  rx, ry;
-    float sample_x = 0.f, sample_y = 0.f;
-    int x1 = 0, y1 = 0;
+  float di, dx, dy;
+  float  rx, ry;
+  float sample_x = 0.f, sample_y = 0.f;
+  int x1 = 0, y1 = 0;
 
-    // Get the information from the keypoint
-    float ratio = (float)(1<<kpt.octave);
-    int scale = fRound(0.5*kpt.size/ratio);
-    float angle = kpt.angle;
-    float level = kpt.class_id;
-    float yf = kpt.pt.y/ratio;
-    float xf = kpt.pt.x/ratio;
-    float co = cos(angle);
-    float si = sin(angle);
+  // Get the information from the keypoint
+  float ratio = (float)(1<<kpt.octave);
+  int scale = fRound(0.5*kpt.size/ratio);
+  float angle = kpt.angle;
+  float level = kpt.class_id;
+  float yf = kpt.pt.y/ratio;
+  float xf = kpt.pt.x/ratio;
+  float co = cos(angle);
+  float si = sin(angle);
 
-    // Allocate memory for the matrix of values
-    Mat values = cv::Mat_<float>::zeros((4+9+16)*descriptor_channels_,1);
+  // Allocate memory for the matrix of values
+  Mat values = cv::Mat_<float>::zeros((4+9+16)*descriptor_channels_,1);
 
-    // Sample everything, but only do the comparisons
-    vector<int> steps(3);
-    steps.at(0) = descriptor_pattern_size_;
-    steps.at(1) = ceil(2.f*descriptor_pattern_size_/3.f);
-    steps.at(2) = descriptor_pattern_size_/2;
+  // Sample everything, but only do the comparisons
+  vector<int> steps(3);
+  steps.at(0) = descriptor_pattern_size_;
+  steps.at(1) = ceil(2.f*descriptor_pattern_size_/3.f);
+  steps.at(2) = descriptor_pattern_size_/2;
 
-    for (int i=0; i<descriptorSamples_.rows; i++) {
-        int *coords = descriptorSamples_.ptr<int>(i);
-        int sample_step = steps.at(coords[0]);
-        di=0.0f;
-        dx=0.0f;
-        dy=0.0f;
+  for (int i=0; i<descriptorSamples_.rows; i++) {
+    int *coords = descriptorSamples_.ptr<int>(i);
+    int sample_step = steps.at(coords[0]);
+    di=0.0f;
+    dx=0.0f;
+    dy=0.0f;
 
-        for (int k = coords[1]; k < coords[1] + sample_step; k++) {
-            for (int l = coords[2]; l < coords[2] + sample_step; l++) {
-                // Get the coordinates of the sample point
-                sample_y = yf + (l*scale*co + k*scale*si);
-                sample_x = xf + (-l*scale*si + k*scale*co);
+    for (int k = coords[1]; k < coords[1] + sample_step; k++) {
+      for (int l = coords[2]; l < coords[2] + sample_step; l++) {
+        // Get the coordinates of the sample point
+        sample_y = yf + (l*scale*co + k*scale*si);
+        sample_x = xf + (-l*scale*si + k*scale*co);
 
-                y1 = fRound(sample_y);
-                x1 = fRound(sample_x);
+        y1 = fRound(sample_y);
+        x1 = fRound(sample_x);
 
-                di += *(evolution_[level].Lt.ptr<float>(y1)+x1);
+        di += *(evolution_[level].Lt.ptr<float>(y1)+x1);
 
-                if (descriptor_channels_ > 1) {
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+        if (descriptor_channels_ > 1) {
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
 
-                    if (descriptor_channels_ == 2) {
-                        dx += sqrtf(rx*rx + ry*ry);
-                    }
-                    else if (descriptor_channels_ == 3) {
-                        // Get the x and y derivatives on the rotated axis
-                        dx += rx*co + ry*si;
-                        dy += -rx*si + ry*co;
-                    }
-                }
-            }
+          if (descriptor_channels_ == 2) {
+            dx += sqrtf(rx*rx + ry*ry);
+          }
+          else if (descriptor_channels_ == 3) {
+            // Get the x and y derivatives on the rotated axis
+            dx += rx*co + ry*si;
+            dy += -rx*si + ry*co;
+          }
         }
-
-        *(values.ptr<float>(descriptor_channels_*i)) = di;
-
-        if (descriptor_channels_ == 2) {
-            *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
-        }
-        else if (descriptor_channels_ == 3) {
-            *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
-            *(values.ptr<float>(descriptor_channels_*i+2)) = dy;
-        }
+      }
     }
 
-    // Do the comparisons
-    const float *vals = values.ptr<float>(0);
-    const int *comps = descriptorBits_.ptr<int>(0);
+    *(values.ptr<float>(descriptor_channels_*i)) = di;
 
-    for (int i=0; i<descriptorBits_.rows; i++) {
-        if (vals[comps[2*i]] > vals[comps[2*i +1]]) {
-            desc[i/8] |= (1<<(i%8));
-        }
+    if (descriptor_channels_ == 2) {
+      *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
     }
+    else if (descriptor_channels_ == 3) {
+      *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
+      *(values.ptr<float>(descriptor_channels_*i+2)) = dy;
+    }
+  }
+
+  // Do the comparisons
+  const float *vals = values.ptr<float>(0);
+  const int *comps = descriptorBits_.ptr<int>(0);
+
+  for (int i=0; i<descriptorBits_.rows; i++) {
+    if (vals[comps[2*i]] > vals[comps[2*i +1]]) {
+      desc[i/8] |= (1<<(i%8));
+    }
+  }
 }
 
 //*************************************************************************************
@@ -1777,78 +1777,78 @@ void AKAZE::Get_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *d
 */
 void AKAZE::Get_Upright_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *desc) {
 
-    float di = 0.0f, dx = 0.0f, dy = 0.0f;
-    float rx = 0.0f, ry = 0.0f;
-    float sample_x = 0.0f, sample_y = 0.0f;
-    int x1 = 0, y1 = 0;
+  float di = 0.0f, dx = 0.0f, dy = 0.0f;
+  float rx = 0.0f, ry = 0.0f;
+  float sample_x = 0.0f, sample_y = 0.0f;
+  int x1 = 0, y1 = 0;
 
-    // Get the information from the keypoint
-    float ratio = (float)(1<<kpt.octave);
-    int scale = fRound(0.5*kpt.size/ratio);
-    float level = kpt.class_id;
-    float yf = kpt.pt.y/ratio;
-    float xf = kpt.pt.x/ratio;
+  // Get the information from the keypoint
+  float ratio = (float)(1<<kpt.octave);
+  int scale = fRound(0.5*kpt.size/ratio);
+  float level = kpt.class_id;
+  float yf = kpt.pt.y/ratio;
+  float xf = kpt.pt.x/ratio;
 
-    // Allocate memory for the matrix of values
-    Mat values = cv::Mat_<float>::zeros((4+9+16)*descriptor_channels_,1);
+  // Allocate memory for the matrix of values
+  Mat values = cv::Mat_<float>::zeros((4+9+16)*descriptor_channels_,1);
 
-    vector<int> steps(3);
-    steps.at(0) = descriptor_pattern_size_;
-    steps.at(1) = ceil(2.f*descriptor_pattern_size_/3.f);
-    steps.at(2) = descriptor_pattern_size_/2;
+  vector<int> steps(3);
+  steps.at(0) = descriptor_pattern_size_;
+  steps.at(1) = ceil(2.f*descriptor_pattern_size_/3.f);
+  steps.at(2) = descriptor_pattern_size_/2;
 
-    for (int i=0; i < descriptorSamples_.rows; i++) {
-        int *coords = descriptorSamples_.ptr<int>(i);
-        int sample_step = steps.at(coords[0]);
-        di=0.0f;
-        dx=0.0f;
-        dy=0.0f;
+  for (int i=0; i < descriptorSamples_.rows; i++) {
+    int *coords = descriptorSamples_.ptr<int>(i);
+    int sample_step = steps.at(coords[0]);
+    di=0.0f;
+    dx=0.0f;
+    dy=0.0f;
 
-        for (int k = coords[1]; k < coords[1] + sample_step; k++) {
-            for (int l = coords[2]; l < coords[2] + sample_step; l++) {
-                // Get the coordinates of the sample point
-                sample_y = yf + l*scale;
-                sample_x = xf + k*scale;
+    for (int k = coords[1]; k < coords[1] + sample_step; k++) {
+      for (int l = coords[2]; l < coords[2] + sample_step; l++) {
+        // Get the coordinates of the sample point
+        sample_y = yf + l*scale;
+        sample_x = xf + k*scale;
 
-                y1 = fRound(sample_y);
-                x1 = fRound(sample_x);
-                di += *(evolution_[level].Lt.ptr<float>(y1)+x1);
+        y1 = fRound(sample_y);
+        x1 = fRound(sample_x);
+        di += *(evolution_[level].Lt.ptr<float>(y1)+x1);
 
-                if (descriptor_channels_ > 1) {
-                    rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
-                    ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
+        if (descriptor_channels_ > 1) {
+          rx = *(evolution_[level].Lx.ptr<float>(y1)+x1);
+          ry = *(evolution_[level].Ly.ptr<float>(y1)+x1);
 
-                    if (descriptor_channels_ == 2) {
-                        dx += sqrtf(rx*rx + ry*ry);
-                    }
-                    else if (descriptor_channels_ == 3) {
-                        dx += rx;
-                        dy += ry;
-                    }
-                }
-            }
+          if (descriptor_channels_ == 2) {
+            dx += sqrtf(rx*rx + ry*ry);
+          }
+          else if (descriptor_channels_ == 3) {
+            dx += rx;
+            dy += ry;
+          }
         }
-
-        *(values.ptr<float>(descriptor_channels_*i)) = di;
-
-        if (descriptor_channels_ == 2) {
-            *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
-        }
-        else if (descriptor_channels_ == 3) {
-            *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
-            *(values.ptr<float>(descriptor_channels_*i+2)) = dy;
-        }
+      }
     }
 
-    // Do the comparisons
-    const float *vals = values.ptr<float>(0);
-    const int *comps = descriptorBits_.ptr<int>(0);
+    *(values.ptr<float>(descriptor_channels_*i)) = di;
 
-    for (int i=0; i<descriptorBits_.rows; i++) {
-        if (vals[comps[2*i]] > vals[comps[2*i +1]]) {
-            desc[i/8] |= (1<<(i%8));
-        }
+    if (descriptor_channels_ == 2) {
+      *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
     }
+    else if (descriptor_channels_ == 3) {
+      *(values.ptr<float>(descriptor_channels_*i+1)) = dx;
+      *(values.ptr<float>(descriptor_channels_*i+2)) = dy;
+    }
+  }
+
+  // Do the comparisons
+  const float *vals = values.ptr<float>(0);
+  const int *comps = descriptorBits_.ptr<int>(0);
+
+  for (int i=0; i<descriptorBits_.rows; i++) {
+    if (vals[comps[2*i]] > vals[comps[2*i +1]]) {
+      desc[i/8] |= (1<<(i%8));
+    }
+  }
 }
 
 //*************************************************************************************
@@ -1859,15 +1859,15 @@ void AKAZE::Get_Upright_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned
 */
 void AKAZE::Save_Scale_Space(void) {
 
-    cv::Mat img_aux;
-    char cad[NMAX_CHAR];
+  cv::Mat img_aux;
+  char cad[NMAX_CHAR];
 
-    for (size_t i = 0; i < evolution_.size(); i++) {
-        convert_scale(evolution_[i].Lt);
-        evolution_[i].Lt.convertTo(img_aux,CV_8U,255.0,0);
-        sprintf(cad,"../output/evolution%02d.jpg",(int)i);
-        imwrite(cad,img_aux);
-    }
+  for (size_t i = 0; i < evolution_.size(); i++) {
+    convert_scale(evolution_[i].Lt);
+    evolution_[i].Lt.convertTo(img_aux,CV_8U,255.0,0);
+    sprintf(cad,"../output/evolution%02d.jpg",(int)i);
+    imwrite(cad,img_aux);
+  }
 }
 
 //*************************************************************************************
@@ -1879,21 +1879,21 @@ void AKAZE::Save_Scale_Space(void) {
 */
 void AKAZE::Save_Detector_Responses(void) {
 
-    Mat img_aux;
-    char cad[NMAX_CHAR];
-    float ttime = 0.0;
-    int nimgs = 0;
+  Mat img_aux;
+  char cad[NMAX_CHAR];
+  float ttime = 0.0;
+  int nimgs = 0;
 
-    for (size_t i = 0; i < evolution_.size(); i++) {
-        ttime = evolution_[i+1].etime-evolution_[i].etime;
-        if (ttime > 0) {
-            convert_scale(evolution_[i].Ldet);
-            evolution_[i].Ldet.convertTo(img_aux,CV_8U,255.0,0);
-            sprintf(cad,"../../output/images/detector_%02d.jpg",nimgs);
-            imwrite(cad,img_aux);
-            nimgs++;
-        } // if ttime
-    } // for i
+  for (size_t i = 0; i < evolution_.size(); i++) {
+    ttime = evolution_[i+1].etime-evolution_[i].etime;
+    if (ttime > 0) {
+      convert_scale(evolution_[i].Ldet);
+      evolution_[i].Ldet.convertTo(img_aux,CV_8U,255.0,0);
+      sprintf(cad,"../../output/images/detector_%02d.jpg",nimgs);
+      imwrite(cad,img_aux);
+      nimgs++;
+    } // if ttime
+  } // for i
 }
 
 
@@ -1905,12 +1905,12 @@ void AKAZE::Save_Detector_Responses(void) {
 */
 void AKAZE::Show_Computation_Times(void) {
 
-    cout << "(*) Time Scale Space: " << tscale_ << endl;
-    cout << "(*) Time Detector: " << tdetector_ << endl;
-    cout << "   - Time Derivatives: " << tderivatives_ << endl;
-    cout << "   - Time Extrema: " << textrema_ << endl;
-    cout << "   - Time Subpixel: " << tsubpixel_ << endl;
-    cout << "(*) Time Descriptor: " << tdescriptor_ << endl;
+  cout << "(*) Time Scale Space: " << tscale_ << endl;
+  cout << "(*) Time Detector: " << tdetector_ << endl;
+  cout << "   - Time Derivatives: " << tderivatives_ << endl;
+  cout << "   - Time Extrema: " << textrema_ << endl;
+  cout << "   - Time Subpixel: " << tsubpixel_ << endl;
+  cout << "(*) Time Descriptor: " << tdescriptor_ << endl;
 }
 
 //*************************************************************************************
@@ -1932,105 +1932,105 @@ void AKAZE::Show_Computation_Times(void) {
 void generateDescriptorSubsample(cv::Mat& sampleList, cv::Mat& comparisons, size_t nbits,
                                  size_t pattern_size, size_t nchannels) {
 
-    size_t ssz = 0;
-    for (int i=0; i<3; i++) {
-        int gz = (i+2)*(i+2);
-        ssz += gz*(gz-1)/2;
+  size_t ssz = 0;
+  for (int i=0; i<3; i++) {
+    int gz = (i+2)*(i+2);
+    ssz += gz*(gz-1)/2;
+  }
+  ssz *= nchannels;
+
+  assert(nbits<=ssz && "descriptor size can't be bigger than full descriptor");
+
+  // Since the full descriptor is usually under 10k elements, we pick
+  // the selection from the full matrix.  We take as many samples per
+  // pick as the number of channels. For every pick, we
+  // take the two samples involved and put them in the sampling list
+
+  Mat_<int> fullM(ssz/nchannels,5);
+  for (size_t i=0, c=0; i<3; i++) {
+    int gdiv = i+2; //grid divisions, per row
+    int gsz = gdiv*gdiv;
+    int psz = ceil(2.*pattern_size/(float)gdiv);
+
+    for (int j=0; j<gsz; j++) {
+      for (int k=j+1; k<gsz; k++,c++) {
+        fullM(c,0) = i;
+        fullM(c,1) = psz*(j % gdiv) - pattern_size;
+        fullM(c,2) = psz*(j / gdiv) - pattern_size;
+        fullM(c,3) = psz*(k % gdiv) - pattern_size;
+        fullM(c,4) = psz*(k / gdiv) - pattern_size;
+      }
     }
-    ssz *= nchannels;
+  }
 
-    assert(nbits<=ssz && "descriptor size can't be bigger than full descriptor");
+  srandom(1024);
+  Mat_<int> comps = cv::Mat_<int>(nchannels*ceil(nbits/(float)nchannels),2);
+  comps = 1000;
 
-    // Since the full descriptor is usually under 10k elements, we pick
-    // the selection from the full matrix.  We take as many samples per
-    // pick as the number of channels. For every pick, we
-    // take the two samples involved and put them in the sampling list
+  // Select some samples. A sample includes all channels
+  int count =0;
+  size_t npicks = ceil(nbits/(float)nchannels);
+  cv::Mat_<int> samples(29,3);
+  cv::Mat_<int> fullcopy = fullM.clone();
+  samples = -1;
 
-    Mat_<int> fullM(ssz/nchannels,5);
-    for (size_t i=0, c=0; i<3; i++) {
-        int gdiv = i+2; //grid divisions, per row
-        int gsz = gdiv*gdiv;
-        int psz = ceil(2.*pattern_size/(float)gdiv);
+  for (size_t i=0; i<npicks; i++) {
+    size_t k = random() % (fullM.rows-i);
 
-        for (int j=0; j<gsz; j++) {
-            for (int k=j+1; k<gsz; k++,c++) {
-                fullM(c,0) = i;
-                fullM(c,1) = psz*(j % gdiv) - pattern_size;
-                fullM(c,2) = psz*(j / gdiv) - pattern_size;
-                fullM(c,3) = psz*(k % gdiv) - pattern_size;
-                fullM(c,4) = psz*(k / gdiv) - pattern_size;
-            }
-        }
-    }
-
-    srandom(1024);
-    Mat_<int> comps = cv::Mat_<int>(nchannels*ceil(nbits/(float)nchannels),2);
-    comps = 1000;
-
-    // Select some samples. A sample includes all channels
-    int count =0;
-    size_t npicks = ceil(nbits/(float)nchannels);
-    cv::Mat_<int> samples(29,3);
-    cv::Mat_<int> fullcopy = fullM.clone();
-    samples = -1;
-
-    for (size_t i=0; i<npicks; i++) {
-        size_t k = random() % (fullM.rows-i);
-
-        if (i < 6) {
-            // Force use of the coarser grid values and comparisons
-            k = i;
-        }
-
-        bool n = true;
-
-        for (int j=0; j<count; j++) {
-            if (samples(j,0) == fullcopy(k,0) && samples(j,1) == fullcopy(k,1) && samples(j,2) == fullcopy(k,2)) {
-                n = false;
-                comps(i*nchannels,0) = nchannels*j;
-                comps(i*nchannels+1,0) = nchannels*j+1;
-                comps(i*nchannels+2,0) = nchannels*j+2;
-                break;
-            }
-        }
-
-        if (n) {
-            samples(count,0) = fullcopy(k,0);
-            samples(count,1) = fullcopy(k,1);
-            samples(count,2) = fullcopy(k,2);
-            comps(i*nchannels,0) = nchannels*count;
-            comps(i*nchannels+1,0) = nchannels*count+1;
-            comps(i*nchannels+2,0) = nchannels*count+2;
-            count++;
-        }
-
-        n = true;
-        for (int j=0; j<count; j++) {
-            if (samples(j,0) == fullcopy(k,0) && samples(j,1) == fullcopy(k,3) && samples(j,2) == fullcopy(k,4)) {
-                n = false;
-                comps(i*nchannels,1) = nchannels*j;
-                comps(i*nchannels+1,1) = nchannels*j+1;
-                comps(i*nchannels+2,1) = nchannels*j+2;
-                break;
-            }
-        }
-
-        if (n) {
-            samples(count,0) = fullcopy(k,0);
-            samples(count,1) = fullcopy(k,3);
-            samples(count,2) = fullcopy(k,4);
-            comps(i*nchannels,1) = nchannels*count;
-            comps(i*nchannels+1,1) = nchannels*count+1;
-            comps(i*nchannels+2,1) = nchannels*count+2;
-            count++;
-        }
-
-        Mat tmp = fullcopy.row(k);
-        fullcopy.row(fullcopy.rows-i-1).copyTo(tmp);
+    if (i < 6) {
+      // Force use of the coarser grid values and comparisons
+      k = i;
     }
 
-    sampleList = samples.rowRange(0,count).clone();
-    comparisons = comps.rowRange(0,nbits).clone();
+    bool n = true;
+
+    for (int j=0; j<count; j++) {
+      if (samples(j,0) == fullcopy(k,0) && samples(j,1) == fullcopy(k,1) && samples(j,2) == fullcopy(k,2)) {
+        n = false;
+        comps(i*nchannels,0) = nchannels*j;
+        comps(i*nchannels+1,0) = nchannels*j+1;
+        comps(i*nchannels+2,0) = nchannels*j+2;
+        break;
+      }
+    }
+
+    if (n) {
+      samples(count,0) = fullcopy(k,0);
+      samples(count,1) = fullcopy(k,1);
+      samples(count,2) = fullcopy(k,2);
+      comps(i*nchannels,0) = nchannels*count;
+      comps(i*nchannels+1,0) = nchannels*count+1;
+      comps(i*nchannels+2,0) = nchannels*count+2;
+      count++;
+    }
+
+    n = true;
+    for (int j=0; j<count; j++) {
+      if (samples(j,0) == fullcopy(k,0) && samples(j,1) == fullcopy(k,3) && samples(j,2) == fullcopy(k,4)) {
+        n = false;
+        comps(i*nchannels,1) = nchannels*j;
+        comps(i*nchannels+1,1) = nchannels*j+1;
+        comps(i*nchannels+2,1) = nchannels*j+2;
+        break;
+      }
+    }
+
+    if (n) {
+      samples(count,0) = fullcopy(k,0);
+      samples(count,1) = fullcopy(k,3);
+      samples(count,2) = fullcopy(k,4);
+      comps(i*nchannels,1) = nchannels*count;
+      comps(i*nchannels+1,1) = nchannels*count+1;
+      comps(i*nchannels+2,1) = nchannels*count+2;
+      count++;
+    }
+
+    Mat tmp = fullcopy.row(k);
+    fullcopy.row(fullcopy.rows-i-1).copyTo(tmp);
+  }
+
+  sampleList = samples.rowRange(0,count).clone();
+  comparisons = comps.rowRange(0,nbits).clone();
 }
 
 //*************************************************************************************
@@ -2041,23 +2041,23 @@ void generateDescriptorSubsample(cv::Mat& sampleList, cv::Mat& comparisons, size
 */
 inline float get_angle(const float& x, const float& y) {
 
-    if (x >= 0 && y >= 0) {
-        return atanf(y/x);
-    }
+  if (x >= 0 && y >= 0) {
+    return atanf(y/x);
+  }
 
-    if (x < 0 && y >= 0) {
-        return CV_PI - atanf(-y/x);
-    }
+  if (x < 0 && y >= 0) {
+    return CV_PI - atanf(-y/x);
+  }
 
-    if (x < 0 && y < 0) {
-        return CV_PI + atanf(y/x);
-    }
+  if (x < 0 && y < 0) {
+    return CV_PI + atanf(y/x);
+  }
 
-    if(x >= 0 && y < 0) {
-        return 2.0*CV_PI - atanf(-y/x);
-    }
+  if(x >= 0 && y < 0) {
+    return 2.0*CV_PI - atanf(-y/x);
+  }
 
-    return 0;
+  return 0;
 }
 
 //**************************************************************************************
@@ -2071,7 +2071,7 @@ inline float get_angle(const float& x, const float& y) {
 */
 inline float gaussian(const float& x, const float& y, const float& sigma) {
 
-    return expf(-(x*x+y*y)/(2.0f*sigma*sigma));
+  return expf(-(x*x+y*y)/(2.0f*sigma*sigma));
 }
 
 //**************************************************************************************
@@ -2086,21 +2086,21 @@ inline float gaussian(const float& x, const float& y, const float& sigma) {
 */
 inline void check_descriptor_limits(int &x, int &y, const int& width, const int& height) {
 
-    if (x < 0) {
-        x = 0;
-    }
+  if (x < 0) {
+    x = 0;
+  }
 
-    if (y < 0) {
-        y = 0;
-    }
+  if (y < 0) {
+    y = 0;
+  }
 
-    if (x > width-1) {
-        x = width-1;
-    }
+  if (x > width-1) {
+    x = width-1;
+  }
 
-    if (y > height-1) {
-        y = height-1;
-    }
+  if (y > height-1) {
+    y = height-1;
+  }
 }
 
 //*************************************************************************************
@@ -2113,6 +2113,6 @@ inline void check_descriptor_limits(int &x, int &y, const int& width, const int&
  */
 inline int fRound(float flt)
 {
-    return (int)(flt+0.5f);
+  return (int)(flt+0.5f);
 }
 

--- a/src/lib/AKAZE.h
+++ b/src/lib/AKAZE.h
@@ -27,128 +27,128 @@ class AKAZE
 
 private:
 
-    // Parameters of the AKAZE class
-    int omax_;               // Maximum octave level
-    int noctaves_;           // Number of octaves
-    int nsublevels_;         // Number of sublevels per octave level
-    int img_width_;          // Width of the original image
-    int img_height_;         // Height of the original image
-    float soffset_;          // Base scale offset
-    float factor_size_;      // Factor for the multiscale derivatives
-    float sderivatives_;     // Standard deviation of the Gaussian for the nonlinear diff. derivatives
-    float kcontrast_;        // The contrast parameter for the scalar nonlinear diffusion
-    float dthreshold_;       // Feature detector threshold response
-    int diffusivity_;        // Diffusivity type, 0->PM G1, 1->PM G2, 2-> Weickert
-    int descriptor_;     // Descriptor mode
-    bool use_upright_;	// Set to true in case we want to use the upright version of the descriptors
-    int descriptor_size_;    // Size of the descriptor in bits. Use 0 for the full descriptor
-    int descriptor_pattern_size_;    // Size of the pattern. Actual size sampled is 2*pattern_size
-    int descriptor_channels_;        // Number of channels to consider in the M-LDB descriptor
-    bool save_scale_space_; // For saving scale space images
-    bool verbosity_;	// Verbosity level
-    std::vector<tevolution> evolution_;	// Vector of nonlinear diffusion evolution
+  // Parameters of the AKAZE class
+  int omax_;               // Maximum octave level
+  int noctaves_;           // Number of octaves
+  int nsublevels_;         // Number of sublevels per octave level
+  int img_width_;          // Width of the original image
+  int img_height_;         // Height of the original image
+  float soffset_;          // Base scale offset
+  float factor_size_;      // Factor for the multiscale derivatives
+  float sderivatives_;     // Standard deviation of the Gaussian for the nonlinear diff. derivatives
+  float kcontrast_;        // The contrast parameter for the scalar nonlinear diffusion
+  float dthreshold_;       // Feature detector threshold response
+  int diffusivity_;        // Diffusivity type, 0->PM G1, 1->PM G2, 2-> Weickert
+  int descriptor_;     // Descriptor mode
+  bool use_upright_;	// Set to true in case we want to use the upright version of the descriptors
+  int descriptor_size_;    // Size of the descriptor in bits. Use 0 for the full descriptor
+  int descriptor_pattern_size_;    // Size of the pattern. Actual size sampled is 2*pattern_size
+  int descriptor_channels_;        // Number of channels to consider in the M-LDB descriptor
+  bool save_scale_space_; // For saving scale space images
+  bool verbosity_;	// Verbosity level
+  std::vector<tevolution> evolution_;	// Vector of nonlinear diffusion evolution
 
-    // FED parameters
-    int ncycles_;                  // Number of cycles
-    bool reordering_;              // Flag for reordering time steps
-    std::vector<std::vector<float > > tsteps_;  // Vector of FED dynamic time steps
-    std::vector<int> nsteps_;      // Vector of number of steps per cycle
+  // FED parameters
+  int ncycles_;                  // Number of cycles
+  bool reordering_;              // Flag for reordering time steps
+  std::vector<std::vector<float > > tsteps_;  // Vector of FED dynamic time steps
+  std::vector<int> nsteps_;      // Vector of number of steps per cycle
 
-    // Some matrices for the M-LDB descriptor computation
-    cv::Mat descriptorSamples_;  // List of positions in the grids to sample LDB bits from.
-    cv::Mat descriptorBits_;
-    cv::Mat bitMask_;
+  // Some matrices for the M-LDB descriptor computation
+  cv::Mat descriptorSamples_;  // List of positions in the grids to sample LDB bits from.
+  cv::Mat descriptorBits_;
+  cv::Mat bitMask_;
 
-    // Computation times variables in ms
-    double tkcontrast_;      // Kcontrast factor computation
-    double tscale_;          // Nonlinear Scale space generation
-    double tderivatives_;    // Multiscale derivatives
-    double tdetector_;       // Feature detector
-    double textrema_;        // Scale Space extrema
-    double tsubpixel_;       // Subpixel refinement
-    double tdescriptor_;     // Feature descriptors
+  // Computation times variables in ms
+  double tkcontrast_;      // Kcontrast factor computation
+  double tscale_;          // Nonlinear Scale space generation
+  double tderivatives_;    // Multiscale derivatives
+  double tdetector_;       // Feature detector
+  double textrema_;        // Scale Space extrema
+  double tsubpixel_;       // Subpixel refinement
+  double tdescriptor_;     // Feature descriptors
 
 public:
 
-    // Constructor
-    AKAZE(const AKAZEOptions &options);
+  // Constructor
+  AKAZE(const AKAZEOptions &options);
 
-    // Destructor
-    ~AKAZE(void);
+  // Destructor
+  ~AKAZE(void);
 
-    // Setters
-    void Set_Octave_Max(const int& omax) {
-        omax_ = omax;
-    }
-    void Set_NSublevels(const int& nsublevels) {
-        nsublevels_ = nsublevels;
-    }
-    void Set_Save_Scale_Space_Flag(const bool& save_scale_space) {
-        save_scale_space_ = save_scale_space;
-    }
-    void Set_Image_Width(const int& img_width) {
-        img_width_ = img_width;
-    }
-    void Set_Image_Height(const int& img_height) {
-        img_height_ = img_height;
-    }
+  // Setters
+  void Set_Octave_Max(const int& omax) {
+    omax_ = omax;
+  }
+  void Set_NSublevels(const int& nsublevels) {
+    nsublevels_ = nsublevels;
+  }
+  void Set_Save_Scale_Space_Flag(const bool& save_scale_space) {
+    save_scale_space_ = save_scale_space;
+  }
+  void Set_Image_Width(const int& img_width) {
+    img_width_ = img_width;
+  }
+  void Set_Image_Height(const int& img_height) {
+    img_height_ = img_height;
+  }
 
-    // Getters
-    int Get_Image_Width(void) {
-        return img_width_;
-    }
-    int Get_Image_Height(void) {
-        return img_height_;
-    }
-    double Get_Time_KContrast(void) {
-        return tkcontrast_;
-    }
-    double Get_Time_Scale_Space(void) {
-        return tscale_;
-    }
-    double Get_Time_Derivatives(void) {
-        return tderivatives_;
-    }
-    double Get_Time_Detector(void) {
-        return tdetector_;
-    }
-    double Get_Time_Descriptor(void) {
-        return tdescriptor_;
-    }
+  // Getters
+  int Get_Image_Width(void) {
+    return img_width_;
+  }
+  int Get_Image_Height(void) {
+    return img_height_;
+  }
+  double Get_Time_KContrast(void) {
+    return tkcontrast_;
+  }
+  double Get_Time_Scale_Space(void) {
+    return tscale_;
+  }
+  double Get_Time_Derivatives(void) {
+    return tderivatives_;
+  }
+  double Get_Time_Detector(void) {
+    return tdetector_;
+  }
+  double Get_Time_Descriptor(void) {
+    return tdescriptor_;
+  }
 
-    // Scale Space methods
-    void Allocate_Memory_Evolution(void);
-    int Create_Nonlinear_Scale_Space(const cv::Mat &img);
-    void Feature_Detection(std::vector<cv::KeyPoint> &kpts);
-    void Compute_Determinant_Hessian_Response(void);
-    void Compute_Multiscale_Derivatives(void);
-    void Determinant_Hessian_Parallel(std::vector<cv::KeyPoint> &kpts);
-    void Find_Scale_Space_Extrema(std::vector<cv::KeyPoint> &kpts);
-    void Do_Subpixel_Refinement(std::vector<cv::KeyPoint> &kpts);
-    void Feature_Suppression_Distance(std::vector<cv::KeyPoint> &kpts, const float& mdist);
+  // Scale Space methods
+  void Allocate_Memory_Evolution(void);
+  int Create_Nonlinear_Scale_Space(const cv::Mat &img);
+  void Feature_Detection(std::vector<cv::KeyPoint> &kpts);
+  void Compute_Determinant_Hessian_Response(void);
+  void Compute_Multiscale_Derivatives(void);
+  void Determinant_Hessian_Parallel(std::vector<cv::KeyPoint> &kpts);
+  void Find_Scale_Space_Extrema(std::vector<cv::KeyPoint> &kpts);
+  void Do_Subpixel_Refinement(std::vector<cv::KeyPoint> &kpts);
+  void Feature_Suppression_Distance(std::vector<cv::KeyPoint> &kpts, const float& mdist);
 
-    // Feature description methods
-    void Compute_Descriptors(std::vector<cv::KeyPoint> &kpts, cv::Mat &desc);
-    void Compute_Main_Orientation_SURF(cv::KeyPoint &kpt);
+  // Feature description methods
+  void Compute_Descriptors(std::vector<cv::KeyPoint> &kpts, cv::Mat &desc);
+  void Compute_Main_Orientation_SURF(cv::KeyPoint &kpt);
 
-    // SURF Pattern Descriptor
-    void Get_SURF_Descriptor_Upright_64(const cv::KeyPoint &kpt, float *desc);
-    void Get_SURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc);
+  // SURF Pattern Descriptor
+  void Get_SURF_Descriptor_Upright_64(const cv::KeyPoint &kpt, float *desc);
+  void Get_SURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc);
 
-    // M-SURF Pattern Descriptor
-    void Get_MSURF_Upright_Descriptor_64(const cv::KeyPoint &kpt, float *desc);
-    void Get_MSURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc);
+  // M-SURF Pattern Descriptor
+  void Get_MSURF_Upright_Descriptor_64(const cv::KeyPoint &kpt, float *desc);
+  void Get_MSURF_Descriptor_64(const cv::KeyPoint &kpt, float *desc);
 
-    // M-LDB Pattern Descriptor
-    void Get_Upright_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *desc);
-    void Get_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *desc);
-    void Get_Upright_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *desc);
-    void Get_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *desc);
+  // M-LDB Pattern Descriptor
+  void Get_Upright_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *desc);
+  void Get_MLDB_Full_Descriptor(const cv::KeyPoint &kpt, unsigned char *desc);
+  void Get_Upright_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *desc);
+  void Get_MLDB_Descriptor_Subset(const cv::KeyPoint &kpt, unsigned char *desc);
 
-    // Methods for saving some results and showing computation times
-    void Save_Scale_Space(void);
-    void Save_Detector_Responses(void);
-    void Show_Computation_Times(void);
+  // Methods for saving some results and showing computation times
+  void Save_Scale_Space(void);
+  void Save_Detector_Responses(void);
+  void Show_Computation_Times(void);
 };
 
 //*************************************************************************************

--- a/src/lib/nldiffusion_functions.cpp
+++ b/src/lib/nldiffusion_functions.cpp
@@ -36,23 +36,23 @@ using namespace cv;
  * @param sigma Kernel standard deviation
  */
 void Gaussian_2D_Convolution(const cv::Mat &src, cv::Mat &dst, size_t ksize_x, size_t ksize_y, const float sigma) {
-    // Compute an appropriate kernel size according to the specified sigma
-    if (sigma > ksize_x || sigma > ksize_y || ksize_x == 0 || ksize_y == 0) {
-        ksize_x = ceil(2.0*(1.0 + (sigma-0.8)/(0.3)));
-        ksize_y = ksize_x;
-    }
+  // Compute an appropriate kernel size according to the specified sigma
+  if (sigma > ksize_x || sigma > ksize_y || ksize_x == 0 || ksize_y == 0) {
+    ksize_x = ceil(2.0*(1.0 + (sigma-0.8)/(0.3)));
+    ksize_y = ksize_x;
+  }
 
-    // The kernel size must be and odd number
-    if ((ksize_x % 2) == 0) {
-        ksize_x += 1;
-    }
+  // The kernel size must be and odd number
+  if ((ksize_x % 2) == 0) {
+    ksize_x += 1;
+  }
 
-    if ((ksize_y % 2) == 0) {
-        ksize_y += 1;
-    }
+  if ((ksize_y % 2) == 0) {
+    ksize_y += 1;
+  }
 
-    // Perform the Gaussian Smoothing with border replication
-    GaussianBlur(src,dst,cv::Size(ksize_x,ksize_y),sigma,sigma,cv::BORDER_REPLICATE);
+  // Perform the Gaussian Smoothing with border replication
+  GaussianBlur(src,dst,cv::Size(ksize_x,ksize_y),sigma,sigma,cv::BORDER_REPLICATE);
 }
 
 //*************************************************************************************
@@ -70,7 +70,7 @@ void Gaussian_2D_Convolution(const cv::Mat &src, cv::Mat &dst, size_t ksize_x, s
  * Journal of Visual Communication and Image Representation 2002
  */
 void Image_Derivatives_Scharr(const cv::Mat &src, cv::Mat &dst, size_t xorder, size_t yorder) {
-    Scharr(src,dst,CV_32F,xorder,yorder,1.0,0,cv::BORDER_DEFAULT);
+  Scharr(src,dst,CV_32F,xorder,yorder,1.0,0,cv::BORDER_DEFAULT);
 }
 
 //*************************************************************************************
@@ -86,7 +86,7 @@ void Image_Derivatives_Scharr(const cv::Mat &src, cv::Mat &dst, size_t xorder, s
  */
 void PM_G1(const cv::Mat &Lx, const cv::Mat &Ly, cv::Mat &dst, const float k)
 {
-    exp(-(Lx.mul(Lx)+Ly.mul(Ly))/(k*k),dst);
+  exp(-(Lx.mul(Lx)+Ly.mul(Ly))/(k*k),dst);
 }
 
 //*************************************************************************************
@@ -101,7 +101,7 @@ void PM_G1(const cv::Mat &Lx, const cv::Mat &Ly, cv::Mat &dst, const float k)
  * @param k Contrast factor parameter
  */
 void PM_G2(const cv::Mat &Lx, const cv::Mat &Ly, cv::Mat &dst, const float k) {
-    dst = 1.0/(1.0+(Lx.mul(Lx)+Ly.mul(Ly))/(k*k));
+  dst = 1.0/(1.0+(Lx.mul(Lx)+Ly.mul(Ly))/(k*k));
 }
 
 //*************************************************************************************
@@ -118,10 +118,10 @@ void PM_G2(const cv::Mat &Lx, const cv::Mat &Ly, cv::Mat &dst, const float k) {
  * Proceedings of Algorithmy 2000
  */
 void Weickert_Diffusivity(const cv::Mat &Lx, const cv::Mat &Ly, cv::Mat &dst, const float k) {
-    Mat modg;
-    pow((Lx.mul(Lx) + Ly.mul(Ly))/(k*k),4,modg);
-    cv::exp(-3.315/modg, dst);
-    dst = 1.0 - dst;
+  Mat modg;
+  pow((Lx.mul(Lx) + Ly.mul(Ly))/(k*k),4,modg);
+  cv::exp(-3.315/modg, dst);
+  dst = 1.0 - dst;
 }
 
 //*************************************************************************************
@@ -141,82 +141,82 @@ void Weickert_Diffusivity(const cv::Mat &Lx, const cv::Mat &Ly, cv::Mat &dst, co
  */
 float Compute_K_Percentile(const cv::Mat &img, const float& perc, const float& gscale,
                            const size_t& nbins, const size_t& ksize_x, const size_t& ksize_y) {
-    size_t nbin = 0, nelements = 0, nthreshold = 0, k = 0;
-    float kperc = 0.0, modg = 0.0, lx = 0.0, ly = 0.0;
-    float npoints = 0.0;
-    float hmax = 0.0;
+  size_t nbin = 0, nelements = 0, nthreshold = 0, k = 0;
+  float kperc = 0.0, modg = 0.0, lx = 0.0, ly = 0.0;
+  float npoints = 0.0;
+  float hmax = 0.0;
 
-    // Create the array for the histogram
-    float *hist = new float[nbins];
+  // Create the array for the histogram
+  float *hist = new float[nbins];
 
-    // Create the matrices
-    Mat gaussian = cv::Mat::zeros(img.rows,img.cols,CV_32F);
-    Mat Lx = cv::Mat::zeros(img.rows,img.cols,CV_32F);
-    Mat Ly = cv::Mat::zeros(img.rows,img.cols,CV_32F);
+  // Create the matrices
+  Mat gaussian = cv::Mat::zeros(img.rows,img.cols,CV_32F);
+  Mat Lx = cv::Mat::zeros(img.rows,img.cols,CV_32F);
+  Mat Ly = cv::Mat::zeros(img.rows,img.cols,CV_32F);
 
-    // Set the histogram to zero, just in case
-    for (size_t i = 0; i < nbins; i++) {
-        hist[i] = 0.0;
+  // Set the histogram to zero, just in case
+  for (size_t i = 0; i < nbins; i++) {
+    hist[i] = 0.0;
+  }
+
+  // Perform the Gaussian convolution
+  Gaussian_2D_Convolution(img,gaussian,ksize_x,ksize_y,gscale);
+
+  // Compute the Gaussian derivatives Lx and Ly
+  Image_Derivatives_Scharr(gaussian,Lx,1,0);
+  Image_Derivatives_Scharr(gaussian,Ly,0,1);
+
+  // Skip the borders for computing the histogram
+  for (int i = 1; i < gaussian.rows-1; i++) {
+    for (int j = 1; j < gaussian.cols-1; j++) {
+      lx = *(Lx.ptr<float>(i)+j);
+      ly = *(Ly.ptr<float>(i)+j);
+      modg = sqrt(lx*lx + ly*ly);
+
+      // Get the maximum
+      if (modg > hmax) {
+        hmax = modg;
+      }
     }
+  }
 
-    // Perform the Gaussian convolution
-    Gaussian_2D_Convolution(img,gaussian,ksize_x,ksize_y,gscale);
+  // Skip the borders for computing the histogram
+  for (int i = 1; i < gaussian.rows-1; i++) {
+    for (int j = 1; j < gaussian.cols-1; j++) {
+      lx = *(Lx.ptr<float>(i)+j);
+      ly = *(Ly.ptr<float>(i)+j);
+      modg = sqrt(lx*lx + ly*ly);
 
-    // Compute the Gaussian derivatives Lx and Ly
-    Image_Derivatives_Scharr(gaussian,Lx,1,0);
-    Image_Derivatives_Scharr(gaussian,Ly,0,1);
+      // Find the correspondent bin
+      if (modg != 0.0) {
+        nbin = floor(nbins*(modg/hmax));
 
-    // Skip the borders for computing the histogram
-    for (int i = 1; i < gaussian.rows-1; i++) {
-        for (int j = 1; j < gaussian.cols-1; j++) {
-            lx = *(Lx.ptr<float>(i)+j);
-            ly = *(Ly.ptr<float>(i)+j);
-            modg = sqrt(lx*lx + ly*ly);
-
-            // Get the maximum
-            if (modg > hmax) {
-                hmax = modg;
-            }
+        if (nbin == nbins) {
+          nbin--;
         }
+
+        hist[nbin]++;
+        npoints++;
+      }
     }
+  }
 
-    // Skip the borders for computing the histogram
-    for (int i = 1; i < gaussian.rows-1; i++) {
-        for (int j = 1; j < gaussian.cols-1; j++) {
-            lx = *(Lx.ptr<float>(i)+j);
-            ly = *(Ly.ptr<float>(i)+j);
-            modg = sqrt(lx*lx + ly*ly);
+  // Now find the perc of the histogram percentile
+  nthreshold = (size_t)(npoints*perc);
 
-            // Find the correspondent bin
-            if (modg != 0.0) {
-                nbin = floor(nbins*(modg/hmax));
+  for (k = 0; nelements < nthreshold && k < nbins; k++) {
+    nelements = nelements + hist[k];
+  }
 
-                if (nbin == nbins) {
-                    nbin--;
-                }
+  if (nelements < nthreshold) {
+    kperc = 0.03;
+  }
+  else {
+    kperc = hmax*((float)(k)/(float)nbins);
+  }
 
-                hist[nbin]++;
-                npoints++;
-            }
-        }
-    }
-
-    // Now find the perc of the histogram percentile
-    nthreshold = (size_t)(npoints*perc);
-
-    for (k = 0; nelements < nthreshold && k < nbins; k++) {
-        nelements = nelements + hist[k];
-    }
-
-    if (nelements < nthreshold) {
-        kperc = 0.03;
-    }
-    else {
-        kperc = hmax*((float)(k)/(float)nbins);
-    }
-
-    delete [] hist;
-    return kperc;
+  delete [] hist;
+  return kperc;
 }
 
 //*************************************************************************************
@@ -232,9 +232,9 @@ float Compute_K_Percentile(const cv::Mat &img, const float& perc, const float& g
  */
 void Compute_Scharr_Derivatives(const cv::Mat &src, cv::Mat &dst, const int& xorder,
                                 const int& yorder, const int& scale) {
-    Mat kx, ky;
-    Compute_Deriv_Kernels(kx, ky, xorder,yorder,scale);
-    sepFilter2D(src,dst,CV_32F,kx,ky);
+  Mat kx, ky;
+  Compute_Deriv_Kernels(kx, ky, xorder,yorder,scale);
+  sepFilter2D(src,dst,CV_32F,kx,ky);
 }
 
 //*************************************************************************************
@@ -254,59 +254,59 @@ void NLD_Step_Scalar(cv::Mat &Ld, const cv::Mat &c, cv::Mat &Lstep, float stepsi
 #ifdef _OPENMP
 #pragma omp parallel for schedule(dynamic)
 #endif
-    for (int i = 1; i < Lstep.rows-1; i++) {
-        for (int j = 1; j < Lstep.cols-1; j++) {
-            float xpos = ((*(c.ptr<float>(i)+j))+(*(c.ptr<float>(i)+j+1)))*((*(Ld.ptr<float>(i)+j+1))-(*(Ld.ptr<float>(i)+j)));
-            float xneg = ((*(c.ptr<float>(i)+j-1))+(*(c.ptr<float>(i)+j)))*((*(Ld.ptr<float>(i)+j))-(*(Ld.ptr<float>(i)+j-1)));
-
-            float ypos = ((*(c.ptr<float>(i)+j))+(*(c.ptr<float>(i+1)+j)))*((*(Ld.ptr<float>(i+1)+j))-(*(Ld.ptr<float>(i)+j)));
-            float yneg = ((*(c.ptr<float>(i-1)+j))+(*(c.ptr<float>(i)+j)))*((*(Ld.ptr<float>(i)+j))-(*(Ld.ptr<float>(i-1)+j)));
-
-            *(Lstep.ptr<float>(i)+j) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
-        }
-    }
-
+  for (int i = 1; i < Lstep.rows-1; i++) {
     for (int j = 1; j < Lstep.cols-1; j++) {
-        float xpos = ((*(c.ptr<float>(0)+j))+(*(c.ptr<float>(0)+j+1)))*((*(Ld.ptr<float>(0)+j+1))-(*(Ld.ptr<float>(0)+j)));
-        float xneg = ((*(c.ptr<float>(0)+j-1))+(*(c.ptr<float>(0)+j)))*((*(Ld.ptr<float>(0)+j))-(*(Ld.ptr<float>(0)+j-1)));
+      float xpos = ((*(c.ptr<float>(i)+j))+(*(c.ptr<float>(i)+j+1)))*((*(Ld.ptr<float>(i)+j+1))-(*(Ld.ptr<float>(i)+j)));
+      float xneg = ((*(c.ptr<float>(i)+j-1))+(*(c.ptr<float>(i)+j)))*((*(Ld.ptr<float>(i)+j))-(*(Ld.ptr<float>(i)+j-1)));
 
-        float ypos = ((*(c.ptr<float>(0)+j))+(*(c.ptr<float>(1)+j)))*((*(Ld.ptr<float>(1)+j))-(*(Ld.ptr<float>(0)+j)));
-        float yneg = ((*(c.ptr<float>(0)+j))+(*(c.ptr<float>(0)+j)))*((*(Ld.ptr<float>(0)+j))-(*(Ld.ptr<float>(0)+j)));
+      float ypos = ((*(c.ptr<float>(i)+j))+(*(c.ptr<float>(i+1)+j)))*((*(Ld.ptr<float>(i+1)+j))-(*(Ld.ptr<float>(i)+j)));
+      float yneg = ((*(c.ptr<float>(i-1)+j))+(*(c.ptr<float>(i)+j)))*((*(Ld.ptr<float>(i)+j))-(*(Ld.ptr<float>(i-1)+j)));
 
-        *(Lstep.ptr<float>(0)+j) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
+      *(Lstep.ptr<float>(i)+j) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
     }
+  }
 
-    for (int j = 1; j < Lstep.cols-1; j++) {
-        float xpos = ((*(c.ptr<float>(Lstep.rows-1)+j))+(*(c.ptr<float>(Lstep.rows-1)+j+1)))*((*(Ld.ptr<float>(Lstep.rows-1)+j+1))-(*(Ld.ptr<float>(Lstep.rows-1)+j)));
-        float xneg = ((*(c.ptr<float>(Lstep.rows-1)+j-1))+(*(c.ptr<float>(Lstep.rows-1)+j)))*((*(Ld.ptr<float>(Lstep.rows-1)+j))-(*(Ld.ptr<float>(Lstep.rows-1)+j-1)));
+  for (int j = 1; j < Lstep.cols-1; j++) {
+    float xpos = ((*(c.ptr<float>(0)+j))+(*(c.ptr<float>(0)+j+1)))*((*(Ld.ptr<float>(0)+j+1))-(*(Ld.ptr<float>(0)+j)));
+    float xneg = ((*(c.ptr<float>(0)+j-1))+(*(c.ptr<float>(0)+j)))*((*(Ld.ptr<float>(0)+j))-(*(Ld.ptr<float>(0)+j-1)));
 
-        float ypos = ((*(c.ptr<float>(Lstep.rows-1)+j))+(*(c.ptr<float>(Lstep.rows-1)+j)))*((*(Ld.ptr<float>(Lstep.rows-1)+j))-(*(Ld.ptr<float>(Lstep.rows-1)+j)));
-        float yneg = ((*(c.ptr<float>(Lstep.rows-2)+j))+(*(c.ptr<float>(Lstep.rows-1)+j)))*((*(Ld.ptr<float>(Lstep.rows-1)+j))-(*(Ld.ptr<float>(Lstep.rows-2)+j)));
+    float ypos = ((*(c.ptr<float>(0)+j))+(*(c.ptr<float>(1)+j)))*((*(Ld.ptr<float>(1)+j))-(*(Ld.ptr<float>(0)+j)));
+    float yneg = ((*(c.ptr<float>(0)+j))+(*(c.ptr<float>(0)+j)))*((*(Ld.ptr<float>(0)+j))-(*(Ld.ptr<float>(0)+j)));
 
-        *(Lstep.ptr<float>(Lstep.rows-1)+j) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
-    }
+    *(Lstep.ptr<float>(0)+j) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
+  }
 
-    for (int i = 1; i < Lstep.rows-1; i++) {
-        float xpos = ((*(c.ptr<float>(i)))+(*(c.ptr<float>(i)+1)))*((*(Ld.ptr<float>(i)+1))-(*(Ld.ptr<float>(i))));
-        float xneg = ((*(c.ptr<float>(i)))+(*(c.ptr<float>(i))))*((*(Ld.ptr<float>(i)))-(*(Ld.ptr<float>(i))));
+  for (int j = 1; j < Lstep.cols-1; j++) {
+    float xpos = ((*(c.ptr<float>(Lstep.rows-1)+j))+(*(c.ptr<float>(Lstep.rows-1)+j+1)))*((*(Ld.ptr<float>(Lstep.rows-1)+j+1))-(*(Ld.ptr<float>(Lstep.rows-1)+j)));
+    float xneg = ((*(c.ptr<float>(Lstep.rows-1)+j-1))+(*(c.ptr<float>(Lstep.rows-1)+j)))*((*(Ld.ptr<float>(Lstep.rows-1)+j))-(*(Ld.ptr<float>(Lstep.rows-1)+j-1)));
 
-        float ypos = ((*(c.ptr<float>(i)))+(*(c.ptr<float>(i+1))))*((*(Ld.ptr<float>(i+1)))-(*(Ld.ptr<float>(i))));
-        float yneg = ((*(c.ptr<float>(i-1)))+(*(c.ptr<float>(i))))*((*(Ld.ptr<float>(i)))-(*(Ld.ptr<float>(i-1))));
+    float ypos = ((*(c.ptr<float>(Lstep.rows-1)+j))+(*(c.ptr<float>(Lstep.rows-1)+j)))*((*(Ld.ptr<float>(Lstep.rows-1)+j))-(*(Ld.ptr<float>(Lstep.rows-1)+j)));
+    float yneg = ((*(c.ptr<float>(Lstep.rows-2)+j))+(*(c.ptr<float>(Lstep.rows-1)+j)))*((*(Ld.ptr<float>(Lstep.rows-1)+j))-(*(Ld.ptr<float>(Lstep.rows-2)+j)));
 
-        *(Lstep.ptr<float>(i)) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
-    }
+    *(Lstep.ptr<float>(Lstep.rows-1)+j) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
+  }
 
-    for (int i = 1; i < Lstep.rows-1; i++) {
-        float xpos = ((*(c.ptr<float>(i)+Lstep.cols-1))+(*(c.ptr<float>(i)+Lstep.cols-1)))*((*(Ld.ptr<float>(i)+Lstep.cols-1))-(*(Ld.ptr<float>(i)+Lstep.cols-1)));
-        float xneg = ((*(c.ptr<float>(i)+Lstep.cols-2))+(*(c.ptr<float>(i)+Lstep.cols-1)))*((*(Ld.ptr<float>(i)+Lstep.cols-1))-(*(Ld.ptr<float>(i)+Lstep.cols-2)));
+  for (int i = 1; i < Lstep.rows-1; i++) {
+    float xpos = ((*(c.ptr<float>(i)))+(*(c.ptr<float>(i)+1)))*((*(Ld.ptr<float>(i)+1))-(*(Ld.ptr<float>(i))));
+    float xneg = ((*(c.ptr<float>(i)))+(*(c.ptr<float>(i))))*((*(Ld.ptr<float>(i)))-(*(Ld.ptr<float>(i))));
 
-        float ypos = ((*(c.ptr<float>(i)+Lstep.cols-1))+(*(c.ptr<float>(i+1)+Lstep.cols-1)))*((*(Ld.ptr<float>(i+1)+Lstep.cols-1))-(*(Ld.ptr<float>(i)+Lstep.cols-1)));
-        float yneg = ((*(c.ptr<float>(i-1)+Lstep.cols-1))+(*(c.ptr<float>(i)+Lstep.cols-1)))*((*(Ld.ptr<float>(i)+Lstep.cols-1))-(*(Ld.ptr<float>(i-1)+Lstep.cols-1)));
+    float ypos = ((*(c.ptr<float>(i)))+(*(c.ptr<float>(i+1))))*((*(Ld.ptr<float>(i+1)))-(*(Ld.ptr<float>(i))));
+    float yneg = ((*(c.ptr<float>(i-1)))+(*(c.ptr<float>(i))))*((*(Ld.ptr<float>(i)))-(*(Ld.ptr<float>(i-1))));
 
-        *(Lstep.ptr<float>(i)+Lstep.cols-1) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
-    }
+    *(Lstep.ptr<float>(i)) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
+  }
 
-    Ld = Ld + Lstep;
+  for (int i = 1; i < Lstep.rows-1; i++) {
+    float xpos = ((*(c.ptr<float>(i)+Lstep.cols-1))+(*(c.ptr<float>(i)+Lstep.cols-1)))*((*(Ld.ptr<float>(i)+Lstep.cols-1))-(*(Ld.ptr<float>(i)+Lstep.cols-1)));
+    float xneg = ((*(c.ptr<float>(i)+Lstep.cols-2))+(*(c.ptr<float>(i)+Lstep.cols-1)))*((*(Ld.ptr<float>(i)+Lstep.cols-1))-(*(Ld.ptr<float>(i)+Lstep.cols-2)));
+
+    float ypos = ((*(c.ptr<float>(i)+Lstep.cols-1))+(*(c.ptr<float>(i+1)+Lstep.cols-1)))*((*(Ld.ptr<float>(i+1)+Lstep.cols-1))-(*(Ld.ptr<float>(i)+Lstep.cols-1)));
+    float yneg = ((*(c.ptr<float>(i-1)+Lstep.cols-1))+(*(c.ptr<float>(i)+Lstep.cols-1)))*((*(Ld.ptr<float>(i)+Lstep.cols-1))-(*(Ld.ptr<float>(i-1)+Lstep.cols-1)));
+
+    *(Lstep.ptr<float>(i)+Lstep.cols-1) = 0.5*stepsize*(xpos-xneg + ypos-yneg);
+  }
+
+  Ld = Ld + Lstep;
 }
 
 //*************************************************************************************
@@ -319,17 +319,17 @@ void NLD_Step_Scalar(cv::Mat &Ld, const cv::Mat &c, cv::Mat &Lstep, float stepsi
  */
 void Downsample_Image(const cv::Mat &src, cv::Mat &dst)
 {
-    int i1 = 0, j1 = 0, i2 = 0, j2 = 0;
+  int i1 = 0, j1 = 0, i2 = 0, j2 = 0;
 
-    for (i1 = 1; i1 < src.rows; i1+=2) {
-        j2 = 0;
-        for (j1 = 1; j1 < src.cols; j1+=2) {
-            *(dst.ptr<float>(i2)+j2) = 0.5*(*(src.ptr<float>(i1)+j1))+0.25*(*(src.ptr<float>(i1)+j1-1) + *(src.ptr<float>(i1)+j1+1));
-            j2++;
-        }
-
-        i2++;
+  for (i1 = 1; i1 < src.rows; i1+=2) {
+    j2 = 0;
+    for (j1 = 1; j1 < src.cols; j1+=2) {
+      *(dst.ptr<float>(i2)+j2) = 0.5*(*(src.ptr<float>(i1)+j1))+0.25*(*(src.ptr<float>(i1)+j1-1) + *(src.ptr<float>(i1)+j1+1));
+      j2++;
     }
+
+    i2++;
+  }
 }
 
 //*************************************************************************************
@@ -341,10 +341,10 @@ void Downsample_Image(const cv::Mat &src, cv::Mat &dst)
  * @param dst Output image with half of the resolution of the input image
  */
 void Halfsample_Image(const cv::Mat &src, cv::Mat &dst) {
-    // Make sure the destination image is of the right size
-    assert(src.cols/2==dst.cols);
-    assert(src.rows/2==dst.rows);
-    cv::resize(src,dst,dst.size(),0,0,cv::INTER_AREA);
+  // Make sure the destination image is of the right size
+  assert(src.cols/2==dst.cols);
+  assert(src.rows/2==dst.rows);
+  cv::resize(src,dst,dst.size(),0,0,cv::INTER_AREA);
 }
 
 //*************************************************************************************
@@ -359,45 +359,45 @@ void Halfsample_Image(const cv::Mat &src, cv::Mat &dst) {
  * @param scale The kernel size
  */
 void Compute_Deriv_Kernels(cv::OutputArray &kx_, cv::OutputArray &ky_, const int& dx, const int& dy, const int& scale) {
-    const int ksize = 3 + 2*(scale-1);
+  const int ksize = 3 + 2*(scale-1);
 
-    if (scale == 1) {
-        // The usual Scharr kernel
-        cv::getDerivKernels(kx_,ky_,dx,dy,0,true,CV_32F);
-        return;
+  if (scale == 1) {
+    // The usual Scharr kernel
+    cv::getDerivKernels(kx_,ky_,dx,dy,0,true,CV_32F);
+    return;
+  }
+
+  kx_.create(ksize,1,CV_32F,-1,true);
+  ky_.create(ksize,1,CV_32F,-1,true);
+  cv::Mat kx = kx_.getMat();
+  cv::Mat ky = ky_.getMat();
+
+  CV_Assert( dx >= 0 && dy >= 0 && dx+dy == 1 );
+
+  float w = 10.0/3.0;
+  float norm = 1.0/(2.0*scale*(w+2.0));
+
+  for (int k = 0; k < 2; k++) {
+    cv::Mat* kernel = k == 0 ? &kx : &ky;
+    int order = k == 0 ? dx : dy;
+    float kerI[ksize];
+
+    for (int t = 0; t<ksize; t++) {
+      kerI[t] = 0;
     }
 
-    kx_.create(ksize,1,CV_32F,-1,true);
-    ky_.create(ksize,1,CV_32F,-1,true);
-    cv::Mat kx = kx_.getMat();
-    cv::Mat ky = ky_.getMat();
-
-    CV_Assert( dx >= 0 && dy >= 0 && dx+dy == 1 );
-
-    float w = 10.0/3.0;
-    float norm = 1.0/(2.0*scale*(w+2.0));
-
-    for (int k = 0; k < 2; k++) {
-        cv::Mat* kernel = k == 0 ? &kx : &ky;
-        int order = k == 0 ? dx : dy;
-        float kerI[ksize];
-
-        for (int t = 0; t<ksize; t++) {
-            kerI[t] = 0;
-        }
-
-        if (order == 0) {
-            kerI[0] = norm;
-            kerI[ksize/2] = w*norm;
-            kerI[ksize-1] = norm;
-        }
-        else if (order == 1) {
-            kerI[0] = -1;
-            kerI[ksize/2] = 0;
-            kerI[ksize-1] = 1;
-        }
-
-        Mat temp(kernel->rows, kernel->cols, CV_32F, &kerI[0]);
-        temp.copyTo(*kernel);
+    if (order == 0) {
+      kerI[0] = norm;
+      kerI[ksize/2] = w*norm;
+      kerI[ksize-1] = norm;
     }
+    else if (order == 1) {
+      kerI[0] = -1;
+      kerI[ksize/2] = 0;
+      kerI[ksize-1] = 1;
+    }
+
+    Mat temp(kernel->rows, kernel->cols, CV_32F, &kerI[0]);
+    temp.copyTo(*kernel);
+  }
 }

--- a/src/lib/utils.cpp
+++ b/src/lib/utils.cpp
@@ -35,17 +35,17 @@ using namespace std;
  */
 void compute_min_32F(const cv::Mat &src, float &value) {
 
-    float aux = 1000.0;
+  float aux = 1000.0;
 
-    for (int i = 0; i < src.rows; i++) {
-        for (int j = 0; j < src.cols; j++) {
-            if (src.at<float>(i,j) < aux) {
-                aux = src.at<float>(i,j);
-            }
-        }
+  for (int i = 0; i < src.rows; i++) {
+    for (int j = 0; j < src.cols; j++) {
+      if (src.at<float>(i,j) < aux) {
+        aux = src.at<float>(i,j);
+      }
     }
+  }
 
-    value = aux;
+  value = aux;
 }
 
 //*************************************************************************************
@@ -58,17 +58,17 @@ void compute_min_32F(const cv::Mat &src, float &value) {
  */
 void compute_max_32F(const cv::Mat &src, float &value) {
 
-    float aux = 0.0;
+  float aux = 0.0;
 
-    for (int i = 0; i < src.rows; i++) {
-        for (int j = 0; j < src.cols; j++) {
-            if (src.at<float>(i,j) > aux) {
-                aux = src.at<float>(i,j);
-            }
-        }
+  for (int i = 0; i < src.rows; i++) {
+    for (int j = 0; j < src.cols; j++) {
+      if (src.at<float>(i,j) > aux) {
+        aux = src.at<float>(i,j);
+      }
     }
+  }
 
-    value = aux;
+  value = aux;
 }
 
 //*************************************************************************************
@@ -81,14 +81,14 @@ void compute_max_32F(const cv::Mat &src, float &value) {
  */
 void convert_scale(cv::Mat &src) {
 
-    float min_val = 0, max_val = 0;
+  float min_val = 0, max_val = 0;
 
-    compute_min_32F(src,min_val);
+  compute_min_32F(src,min_val);
 
-    src = src - min_val;
+  src = src - min_val;
 
-    compute_max_32F(src,max_val);
-    src = src / max_val;
+  compute_max_32F(src,max_val);
+  src = src / max_val;
 }
 
 //*************************************************************************************
@@ -102,15 +102,15 @@ void convert_scale(cv::Mat &src) {
  */
 void copy_and_convert_scale(const cv::Mat &src, cv::Mat dst) {
 
-    float min_val = 0, max_val = 0;
+  float min_val = 0, max_val = 0;
 
-    src.copyTo(dst);
-    compute_min_32F(dst,min_val);
+  src.copyTo(dst);
+  compute_min_32F(dst,min_val);
 
-    dst = dst - min_val;
+  dst = dst - min_val;
 
-    compute_max_32F(dst,max_val);
-    dst = dst / max_val;
+  compute_max_32F(dst,max_val);
+  dst = dst / max_val;
 }
 
 //*************************************************************************************
@@ -123,16 +123,16 @@ void copy_and_convert_scale(const cv::Mat &src, cv::Mat dst) {
  */
 void draw_keypoints(cv::Mat &img, const std::vector<cv::KeyPoint> &kpts) {
 
-    int x = 0, y = 0;
-    float radius = 0.0;
+  int x = 0, y = 0;
+  float radius = 0.0;
 
-    for (size_t i = 0; i < kpts.size(); i++) {
-        x = (int)(kpts[i].pt.x+.5);
-        y = (int)(kpts[i].pt.y+.5);
-        radius = kpts[i].size/2.0;
-        cv::circle(img,cv::Point(x,y),radius*2.50,CV_RGB(0,255,0),1);
-        cv::circle(img,cv::Point(x,y),1.0,CV_RGB(0,0,255),-1);
-    }
+  for (size_t i = 0; i < kpts.size(); i++) {
+    x = (int)(kpts[i].pt.x+.5);
+    y = (int)(kpts[i].pt.y+.5);
+    radius = kpts[i].size/2.0;
+    cv::circle(img,cv::Point(x,y),radius*2.50,CV_RGB(0,255,0),1);
+    cv::circle(img,cv::Point(x,y),1.0,CV_RGB(0,0,255),-1);
+  }
 }
 
 //*************************************************************************************
@@ -148,57 +148,57 @@ void draw_keypoints(cv::Mat &img, const std::vector<cv::KeyPoint> &kpts) {
  */
 int save_keypoints(char *outFile, const std::vector<cv::KeyPoint> &kpts, const cv::Mat &desc, bool save_desc) {
 
-    int nkpts = 0, dsize = 0;
-    float sc = 0.0;
+  int nkpts = 0, dsize = 0;
+  float sc = 0.0;
 
-    nkpts = (int)(kpts.size());
-    dsize = (int)(desc.cols);
+  nkpts = (int)(kpts.size());
+  dsize = (int)(desc.cols);
 
-    ofstream ipfile(outFile);
+  ofstream ipfile(outFile);
 
-    if (!ipfile) {
-        cerr << "Couldn't open file '" << outFile << "'!" << endl;
-        return -1;
+  if (!ipfile) {
+    cerr << "Couldn't open file '" << outFile << "'!" << endl;
+    return -1;
+  }
+
+  if (save_desc == false) {
+    ipfile << 1 << endl << nkpts << endl;
+  }
+  else {
+    ipfile << dsize << endl << nkpts << endl;
+  }
+
+  // Save interest point with descriptor in the format of Krystian Mikolajczyk
+  // for reasons of comparison with other descriptors
+  for (int i = 0; i < nkpts; i++) {
+    // Radius of the keypoint
+    sc = (kpts[i].size);
+    sc*=sc;
+
+    ipfile  << kpts[i].pt.x /* x-location of the interest point */
+    << " " << kpts[i].pt.y /* y-location of the interest point */
+    << " " << 1.0/sc /* 1/r^2 */
+    << " " << 0.0
+    << " " << 1.0/sc; /* 1/r^2 */
+
+    // Here comes the descriptor
+    for( int j = 0; j < dsize; j++) {
+      if (desc.type() == 0) {
+        ipfile << " " << (int)(desc.at<unsigned char>(i,j));
+      }
+      else {
+        ipfile << " " << (desc.at<float>(i,j));
+      }
     }
 
-    if (save_desc == false) {
-        ipfile << 1 << endl << nkpts << endl;
-    }
-    else {
-        ipfile << dsize << endl << nkpts << endl;
-    }
-
-    // Save interest point with descriptor in the format of Krystian Mikolajczyk
-    // for reasons of comparison with other descriptors
-    for (int i = 0; i < nkpts; i++) {
-        // Radius of the keypoint
-        sc = (kpts[i].size);
-        sc*=sc;
-
-        ipfile  << kpts[i].pt.x /* x-location of the interest point */
-                << " " << kpts[i].pt.y /* y-location of the interest point */
-                << " " << 1.0/sc /* 1/r^2 */
-                << " " << 0.0
-                << " " << 1.0/sc; /* 1/r^2 */
-
-        // Here comes the descriptor
-        for( int j = 0; j < dsize; j++) {
-            if (desc.type() == 0) {
-                ipfile << " " << (int)(desc.at<unsigned char>(i,j));
-            }
-            else {
-                ipfile << " " << (desc.at<float>(i,j));
-            }
-        }
-
-        ipfile << endl;
-    }
+    ipfile << endl;
+  }
 
 
-    // Close the txt file
-    ipfile.close();
+  // Close the txt file
+  ipfile.close();
 
-    return 0;
+  return 0;
 }
 
 //*******************************************************************************
@@ -217,17 +217,17 @@ void matches2points_nndr(const std::vector<cv::KeyPoint> &train, const std::vect
                          const std::vector<std::vector<cv::DMatch> > &matches,
                          std::vector<cv::Point2f> &pmatches, float nndr) {
 
-    float dist1 = 0.0, dist2 = 0.0;
-    for (size_t i = 0; i < matches.size(); i++) {
-        cv::DMatch dmatch = matches[i][0];
-        dist1 = matches[i][0].distance;
-        dist2 = matches[i][1].distance;
+  float dist1 = 0.0, dist2 = 0.0;
+  for (size_t i = 0; i < matches.size(); i++) {
+    cv::DMatch dmatch = matches[i][0];
+    dist1 = matches[i][0].distance;
+    dist2 = matches[i][1].distance;
 
-        if (dist1 < nndr*dist2) {
-            pmatches.push_back(train[dmatch.queryIdx].pt);
-            pmatches.push_back(query[dmatch.trainIdx].pt);
-        }
+    if (dist1 < nndr*dist2) {
+      pmatches.push_back(train[dmatch.queryIdx].pt);
+      pmatches.push_back(query[dmatch.trainIdx].pt);
     }
+  }
 }
 
 //*******************************************************************************
@@ -244,29 +244,29 @@ void matches2points_nndr(const std::vector<cv::KeyPoint> &train, const std::vect
 void compute_inliers_ransac(const std::vector<cv::Point2f> &matches, std::vector<cv::Point2f> &inliers,
                             const float& error, const bool& use_fund) {
 
-    std::vector<cv::Point2f> points1, points2;
-    cv::Mat H = cv::Mat::zeros(3,3,CV_32F);
-    int npoints = matches.size()/2;
-    cv::Mat status = cv::Mat::zeros(npoints,1,CV_8UC1);
+  std::vector<cv::Point2f> points1, points2;
+  cv::Mat H = cv::Mat::zeros(3,3,CV_32F);
+  int npoints = matches.size()/2;
+  cv::Mat status = cv::Mat::zeros(npoints,1,CV_8UC1);
 
-    for (size_t i = 0; i < matches.size(); i+=2) {
-        points1.push_back(matches[i]);
-        points2.push_back(matches[i+1]);
-    }
+  for (size_t i = 0; i < matches.size(); i+=2) {
+    points1.push_back(matches[i]);
+    points2.push_back(matches[i+1]);
+  }
 
-    if (use_fund == true){
-        H = cv::findFundamentalMat(points1,points2,CV_FM_RANSAC,error,0.99,status);
-    }
-    else {
-        H = cv::findHomography(points1,points2,CV_RANSAC,error,status);
-    }
+  if (use_fund == true) {
+    H = cv::findFundamentalMat(points1,points2,CV_FM_RANSAC,error,0.99,status);
+  }
+  else {
+    H = cv::findHomography(points1,points2,CV_RANSAC,error,status);
+  }
 
-    for (int i = 0; i < npoints; i++) {
-        if (status.at<unsigned char>(i) == 1) {
-            inliers.push_back(points1[i]);
-            inliers.push_back(points2[i]);
-        }
+  for (int i = 0; i < npoints; i++) {
+    if (status.at<unsigned char>(i) == 1) {
+      inliers.push_back(points1[i]);
+      inliers.push_back(points2[i]);
     }
+  }
 }
 
 //*************************************************************************************
@@ -281,42 +281,42 @@ void compute_inliers_ransac(const std::vector<cv::Point2f> &matches, std::vector
  */
 void compute_inliers_homography(const std::vector<cv::Point2f> &matches,
                                 std::vector<cv::Point2f> &inliers, const cv::Mat &H, const float& min_error) {
-    float h11 = 0.0, h12 = 0.0, h13 = 0.0;
-    float h21 = 0.0, h22 = 0.0, h23 = 0.0;
-    float h31 = 0.0, h32 = 0.0, h33 = 0.0;
-    float x1 = 0.0, y1 = 0.0;
-    float x2 = 0.0, y2 = 0.0;
-    float x2m = 0.0, y2m = 0.0;
-    float dist = 0.0, s = 0.0;
+  float h11 = 0.0, h12 = 0.0, h13 = 0.0;
+  float h21 = 0.0, h22 = 0.0, h23 = 0.0;
+  float h31 = 0.0, h32 = 0.0, h33 = 0.0;
+  float x1 = 0.0, y1 = 0.0;
+  float x2 = 0.0, y2 = 0.0;
+  float x2m = 0.0, y2m = 0.0;
+  float dist = 0.0, s = 0.0;
 
-    h11 = H.at<float>(0,0);
-    h12 = H.at<float>(0,1);
-    h13 = H.at<float>(0,2);
-    h21 = H.at<float>(1,0);
-    h22 = H.at<float>(1,1);
-    h23 = H.at<float>(1,2);
-    h31 = H.at<float>(2,0);
-    h32 = H.at<float>(2,1);
-    h33 = H.at<float>(2,2);
+  h11 = H.at<float>(0,0);
+  h12 = H.at<float>(0,1);
+  h13 = H.at<float>(0,2);
+  h21 = H.at<float>(1,0);
+  h22 = H.at<float>(1,1);
+  h23 = H.at<float>(1,2);
+  h31 = H.at<float>(2,0);
+  h32 = H.at<float>(2,1);
+  h33 = H.at<float>(2,2);
 
-    inliers.clear();
+  inliers.clear();
 
-    for (size_t i = 0; i < matches.size(); i+=2) {
-        x1 = matches[i].x;
-        y1 = matches[i].y;
-        x2 = matches[i+1].x;
-        y2 = matches[i+1].y;
+  for (size_t i = 0; i < matches.size(); i+=2) {
+    x1 = matches[i].x;
+    y1 = matches[i].y;
+    x2 = matches[i+1].x;
+    y2 = matches[i+1].y;
 
-        s = h31*x1 + h32*y1 + h33;
-        x2m = (h11*x1 + h12*y1 + h13) / s;
-        y2m = (h21*x1 + h22*y1 + h23) / s;
-        dist = sqrt( pow(x2m-x2,2) + pow(y2m-y2,2));
+    s = h31*x1 + h32*y1 + h33;
+    x2m = (h11*x1 + h12*y1 + h13) / s;
+    y2m = (h21*x1 + h22*y1 + h23) / s;
+    dist = sqrt( pow(x2m-x2,2) + pow(y2m-y2,2));
 
-        if (dist <= min_error) {
-            inliers.push_back(matches[i]);
-            inliers.push_back(matches[i+1]);
-        }
+    if (dist <= min_error) {
+      inliers.push_back(matches[i]);
+      inliers.push_back(matches[i+1]);
     }
+  }
 }
 
 //*******************************************************************************
@@ -331,44 +331,44 @@ void compute_inliers_homography(const std::vector<cv::Point2f> &matches,
  */
 void draw_inliers(const cv::Mat &img1, const cv::Mat &img2, cv::Mat &img_com,
                   const std::vector<cv::Point2f> &ptpairs) {
-    int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
-    float rows1 = 0.0, cols1 = 0.0;
-    float rows2 = 0.0, cols2 = 0.0;
-    float ufactor = 0.0, vfactor = 0.0;
+  int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+  float rows1 = 0.0, cols1 = 0.0;
+  float rows2 = 0.0, cols2 = 0.0;
+  float ufactor = 0.0, vfactor = 0.0;
 
-    rows1 = img1.rows;
-    cols1 = img1.cols;
-    rows2 = img2.rows;
-    cols2 = img2.cols;
-    ufactor = (float)(cols1)/(float)(cols2);
-    vfactor = (float)(rows1)/(float)(rows2);
+  rows1 = img1.rows;
+  cols1 = img1.cols;
+  rows2 = img2.rows;
+  cols2 = img2.cols;
+  ufactor = (float)(cols1)/(float)(cols2);
+  vfactor = (float)(rows1)/(float)(rows2);
 
-    // This is in case the input images don't have the same resolution
-    cv::Mat img_aux = cv::Mat(cv::Size(img1.cols,img1.rows),CV_8UC3);
-    cv::resize(img2,img_aux,cv::Size(img1.cols,img1.rows),0,0,CV_INTER_LINEAR);
+  // This is in case the input images don't have the same resolution
+  cv::Mat img_aux = cv::Mat(cv::Size(img1.cols,img1.rows),CV_8UC3);
+  cv::resize(img2,img_aux,cv::Size(img1.cols,img1.rows),0,0,CV_INTER_LINEAR);
 
-    for (int i = 0; i < img_com.rows; i++) {
-        for (int j = 0; j < img_com.cols; j++) {
-            if (j < img1.cols) {
-                *(img_com.ptr<unsigned char>(i)+3*j) = *(img1.ptr<unsigned char>(i)+3*j);
-                *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img1.ptr<unsigned char>(i)+3*j+1);
-                *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img1.ptr<unsigned char>(i)+3*j+2);
-            }
-            else {
-                *(img_com.ptr<unsigned char>(i)+3*j) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols));
-                *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+1);
-                *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+2);
-            }
-        }
+  for (int i = 0; i < img_com.rows; i++) {
+    for (int j = 0; j < img_com.cols; j++) {
+      if (j < img1.cols) {
+        *(img_com.ptr<unsigned char>(i)+3*j) = *(img1.ptr<unsigned char>(i)+3*j);
+        *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img1.ptr<unsigned char>(i)+3*j+1);
+        *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img1.ptr<unsigned char>(i)+3*j+2);
+      }
+      else {
+        *(img_com.ptr<unsigned char>(i)+3*j) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols));
+        *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+1);
+        *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+2);
+      }
     }
+  }
 
-    for (size_t i = 0; i < ptpairs.size(); i+= 2) {
-        x1 = (int)(ptpairs[i].x+.5);
-        y1 = (int)(ptpairs[i].y+.5);
-        x2 = (int)(ptpairs[i+1].x*ufactor+img1.cols+.5);
-        y2 = (int)(ptpairs[i+1].y*vfactor+.5);
-        cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(255,0,0),2);
-    }
+  for (size_t i = 0; i < ptpairs.size(); i+= 2) {
+    x1 = (int)(ptpairs[i].x+.5);
+    y1 = (int)(ptpairs[i].y+.5);
+    x2 = (int)(ptpairs[i+1].x*ufactor+img1.cols+.5);
+    y2 = (int)(ptpairs[i+1].y*vfactor+.5);
+    cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(255,0,0),2);
+  }
 }
 
 //*******************************************************************************
@@ -384,53 +384,53 @@ void draw_inliers(const cv::Mat &img1, const cv::Mat &img2, cv::Mat &img_com,
  */
 void draw_inliers(const cv::Mat &img1, const cv::Mat &img2, cv::Mat &img_com,
                   const std::vector<cv::Point2f> &ptpairs, const int color) {
-    int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
-    float rows1 = 0.0, cols1 = 0.0;
-    float rows2 = 0.0, cols2 = 0.0;
-    float ufactor = 0.0, vfactor = 0.0;
+  int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+  float rows1 = 0.0, cols1 = 0.0;
+  float rows2 = 0.0, cols2 = 0.0;
+  float ufactor = 0.0, vfactor = 0.0;
 
-    rows1 = img1.rows;
-    cols1 = img1.cols;
-    rows2 = img2.rows;
-    cols2 = img2.cols;
-    ufactor = (float)(cols1)/(float)(cols2);
-    vfactor = (float)(rows1)/(float)(rows2);
+  rows1 = img1.rows;
+  cols1 = img1.cols;
+  rows2 = img2.rows;
+  cols2 = img2.cols;
+  ufactor = (float)(cols1)/(float)(cols2);
+  vfactor = (float)(rows1)/(float)(rows2);
 
-    // This is in case the input images don't have the same resolution
-    cv::Mat img_aux = cv::Mat(cv::Size(img1.cols,img1.rows),CV_8UC3);
-    cv::resize(img2,img_aux,cv::Size(img1.cols,img1.rows),0,0,CV_INTER_LINEAR);
+  // This is in case the input images don't have the same resolution
+  cv::Mat img_aux = cv::Mat(cv::Size(img1.cols,img1.rows),CV_8UC3);
+  cv::resize(img2,img_aux,cv::Size(img1.cols,img1.rows),0,0,CV_INTER_LINEAR);
 
-    for (int i = 0; i < img_com.rows; i++) {
-        for (int j = 0; j < img_com.cols; j++) {
-            if ( j < img1.cols ) {
-                *(img_com.ptr<unsigned char>(i)+3*j) = *(img1.ptr<unsigned char>(i)+3*j);
-                *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img1.ptr<unsigned char>(i)+3*j+1);
-                *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img1.ptr<unsigned char>(i)+3*j+2);
-            }
-            else {
-                *(img_com.ptr<unsigned char>(i)+3*j) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols));
-                *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+1);
-                *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+2);
-            }
-        }
+  for (int i = 0; i < img_com.rows; i++) {
+    for (int j = 0; j < img_com.cols; j++) {
+      if ( j < img1.cols ) {
+        *(img_com.ptr<unsigned char>(i)+3*j) = *(img1.ptr<unsigned char>(i)+3*j);
+        *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img1.ptr<unsigned char>(i)+3*j+1);
+        *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img1.ptr<unsigned char>(i)+3*j+2);
+      }
+      else {
+        *(img_com.ptr<unsigned char>(i)+3*j) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols));
+        *(img_com.ptr<unsigned char>(i)+3*j+1) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+1);
+        *(img_com.ptr<unsigned char>(i)+3*j+2) = *(img2.ptr<unsigned char>(i)+3*(j-img_aux.cols)+2);
+      }
     }
+  }
 
-    for (size_t i = 0; i < ptpairs.size(); i+= 2) {
-        x1 = (int)(ptpairs[i].x+.5);
-        y1 = (int)(ptpairs[i].y+.5);
-        x2 = (int)(ptpairs[i+1].x*ufactor+img1.cols+.5);
-        y2 = (int)(ptpairs[i+1].y*vfactor+.5);
+  for (size_t i = 0; i < ptpairs.size(); i+= 2) {
+    x1 = (int)(ptpairs[i].x+.5);
+    y1 = (int)(ptpairs[i].y+.5);
+    x2 = (int)(ptpairs[i+1].x*ufactor+img1.cols+.5);
+    y2 = (int)(ptpairs[i+1].y*vfactor+.5);
 
-        if (color == 0) {
-            cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(255,255,0),2);
-        }
-        else if (color == 1) {
-            cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(255,0,0),2);
-        }
-        else if (color == 2) {
-            cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(0,0,255),2);
-        }
+    if (color == 0) {
+      cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(255,255,0),2);
     }
+    else if (color == 1) {
+      cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(255,0,0),2);
+    }
+    else if (color == 2) {
+      cv::line(img_com,cv::Point(x1,y1),cv::Point(x2,y2),CV_RGB(0,0,255),2);
+    }
+  }
 }
 
 //*************************************************************************************
@@ -442,45 +442,45 @@ void draw_inliers(const cv::Mat &img1, const cv::Mat &img2, cv::Mat &img_com,
  * @param H1toN Matrix to store the ground truth homography
  */
 void read_homography(const char *hFile, cv::Mat &H1toN) {
-    float h11 = 0.0, h12 = 0.0, h13 = 0.0;
-    float h21 = 0.0, h22 = 0.0, h23 = 0.0;
-    float h31 = 0.0, h32 = 0.0, h33 = 0.0;
-    int  tmp_buf_size = 256;
-    char tmp_buf[tmp_buf_size];
-    string tmp_string;
+  float h11 = 0.0, h12 = 0.0, h13 = 0.0;
+  float h21 = 0.0, h22 = 0.0, h23 = 0.0;
+  float h31 = 0.0, h32 = 0.0, h33 = 0.0;
+  int  tmp_buf_size = 256;
+  char tmp_buf[tmp_buf_size];
+  string tmp_string;
 
-    // Allocate memory for the OpenCV matrices
-    H1toN = cv::Mat::zeros(3,3,CV_32FC1);
+  // Allocate memory for the OpenCV matrices
+  H1toN = cv::Mat::zeros(3,3,CV_32FC1);
 
-    setlocale(LC_ALL,"C");
+  setlocale(LC_ALL,"C");
 
-    string filename(hFile);
-    ifstream infile;
-    infile.exceptions ( std::ifstream::eofbit | std::ifstream::failbit | std::ifstream::badbit );
-    infile.open(filename.c_str(), std::ifstream::in);
+  string filename(hFile);
+  ifstream infile;
+  infile.exceptions ( std::ifstream::eofbit | std::ifstream::failbit | std::ifstream::badbit );
+  infile.open(filename.c_str(), std::ifstream::in);
 
-    infile.getline(tmp_buf,tmp_buf_size);
-    sscanf(tmp_buf,"%f %f %f",&h11,&h12,&h13);
+  infile.getline(tmp_buf,tmp_buf_size);
+  sscanf(tmp_buf,"%f %f %f",&h11,&h12,&h13);
 
-    infile.getline(tmp_buf,tmp_buf_size);
-    sscanf(tmp_buf,"%f %f %f",&h21,&h22,&h23);
+  infile.getline(tmp_buf,tmp_buf_size);
+  sscanf(tmp_buf,"%f %f %f",&h21,&h22,&h23);
 
-    infile.getline(tmp_buf,tmp_buf_size);
-    sscanf(tmp_buf,"%f %f %f",&h31,&h32,&h33);
+  infile.getline(tmp_buf,tmp_buf_size);
+  sscanf(tmp_buf,"%f %f %f",&h31,&h32,&h33);
 
-    infile.close();
+  infile.close();
 
-    H1toN.at<float>(0,0) = h11 / h33;
-    H1toN.at<float>(0,1) = h12 / h33;
-    H1toN.at<float>(0,2) = h13 / h33;
+  H1toN.at<float>(0,0) = h11 / h33;
+  H1toN.at<float>(0,1) = h12 / h33;
+  H1toN.at<float>(0,2) = h13 / h33;
 
-    H1toN.at<float>(1,0) = h21 / h33;
-    H1toN.at<float>(1,1) = h22 / h33;
-    H1toN.at<float>(1,2) = h23 / h33;
+  H1toN.at<float>(1,0) = h21 / h33;
+  H1toN.at<float>(1,1) = h22 / h33;
+  H1toN.at<float>(1,2) = h23 / h33;
 
-    H1toN.at<float>(2,0) = h31 / h33;
-    H1toN.at<float>(2,1) = h32 / h33;
-    H1toN.at<float>(2,2) = h33 / h33;
+  H1toN.at<float>(2,0) = h31 / h33;
+  H1toN.at<float>(2,1) = h32 / h33;
+  H1toN.at<float>(2,2) = h33 / h33;
 }
 
 //*************************************************************************************
@@ -491,34 +491,34 @@ void read_homography(const char *hFile, cv::Mat &H1toN) {
  */
 void show_input_options_help(int example) {
 
-    fflush(stdout);
+  fflush(stdout);
 
-    cout << "A-KAZE Features" << endl;
-    cout << "************************************************" << endl;
-    cout << "For running the program you need to type in the command line the following arguments: " << endl;
+  cout << "A-KAZE Features" << endl;
+  cout << "************************************************" << endl;
+  cout << "For running the program you need to type in the command line the following arguments: " << endl;
 
-    if (example == 0) {
-        cout << "./akaze_features img.jpg options" << endl;
-    }
-    else if (example == 1) {
-        cout << "./akaze_match img1.jpg img2.pgm homography.txt options" << endl;
-    }
-    else if (example == 2) {
-        cout << "./akaze_compare img1.jpg img2.pgm homography.txt options" << endl;
-    }
+  if (example == 0) {
+    cout << "./akaze_features img.jpg options" << endl;
+  }
+  else if (example == 1) {
+    cout << "./akaze_match img1.jpg img2.pgm homography.txt options" << endl;
+  }
+  else if (example == 2) {
+    cout << "./akaze_compare img1.jpg img2.pgm homography.txt options" << endl;
+  }
 
-    cout << "The options are not mandatory. In case you do not specify additional options, default arguments will be used" << endl << endl;
-    cout << "Here is a description of the additional options: " << endl;
-    cout << "--verbose " << "\t\t if verbosity is required" << endl;
-    cout << "--help" << "\t\t for showing the command line options" << endl;
-    cout << "--soffset" << "\t\t the base scale offset (sigma units)" << endl;
-    cout << "--omax" << "\t\t maximum octave evolution of the image 2^sigma (coarsest scale)" << endl;
-    cout << "--nsublevels" << "\t\t number of sublevels per octave" << endl;
-    cout << "--diffusivity" << "\t\t diffusivity function 0 -> PM 1, 1 -> PM 2, 2 -> Weickert" << endl;
-    cout << "--dthreshold" << "\t\t Feature detector threshold response for accepting points (0.001 can be a good value)" << endl;
-    cout << "--descriptor" << "\t\t Descriptor Type 0 -> SURF_UPRIGHT, 1 -> SURF, 2 -> M-SURF_UPRIGHT, 3 -> M-SURF, 4 -> M-LDB_UPRIGHT, 5 -> M-LDB" << endl;
-    cout << "--descriptor_channels " <<"\t\t Descriptor Channels for M-LDB (valid values: 1, 2 (intensity+grdient magnitude), 3(intensity + X and Y gradients" <<endl;
-    cout << "--descriptor_size" << "\t\t Descriptor size for M-LDB in bits. 0 means the full length descriptor (486)!!" << endl;
-    cout << "--show_results" << "\t\t 1 in case we want to show detection results. 0 otherwise" << endl;
-    cout << endl;
+  cout << "The options are not mandatory. In case you do not specify additional options, default arguments will be used" << endl << endl;
+  cout << "Here is a description of the additional options: " << endl;
+  cout << "--verbose " << "\t\t if verbosity is required" << endl;
+  cout << "--help" << "\t\t for showing the command line options" << endl;
+  cout << "--soffset" << "\t\t the base scale offset (sigma units)" << endl;
+  cout << "--omax" << "\t\t maximum octave evolution of the image 2^sigma (coarsest scale)" << endl;
+  cout << "--nsublevels" << "\t\t number of sublevels per octave" << endl;
+  cout << "--diffusivity" << "\t\t diffusivity function 0 -> PM 1, 1 -> PM 2, 2 -> Weickert" << endl;
+  cout << "--dthreshold" << "\t\t Feature detector threshold response for accepting points (0.001 can be a good value)" << endl;
+  cout << "--descriptor" << "\t\t Descriptor Type 0 -> SURF_UPRIGHT, 1 -> SURF, 2 -> M-SURF_UPRIGHT, 3 -> M-SURF, 4 -> M-LDB_UPRIGHT, 5 -> M-LDB" << endl;
+  cout << "--descriptor_channels " <<"\t\t Descriptor Channels for M-LDB (valid values: 1, 2 (intensity+grdient magnitude), 3(intensity + X and Y gradients" <<endl;
+  cout << "--descriptor_size" << "\t\t Descriptor size for M-LDB in bits. 0 means the full length descriptor (486)!!" << endl;
+  cout << "--show_results" << "\t\t 1 in case we want to show detection results. 0 otherwise" << endl;
+  cout << endl;
 }


### PR DESCRIPTION
I think we must update the markdown for the descriptor choice.

  SURF_UPRIGHT = 0, // Upright descriptors, not invariant to rotation
  SURF = 1,
  MSURF_UPRIGHT = 2, // Upright descriptors, not invariant to rotation
  MSURF = 3,
  MLDB_UPRIGHT = 4, // Upright descriptors, not invariant to rotation
  MLDB = 5
