### PR TITLE
Fix Visual Studio compilation with OpenMP

### DIFF
--- a/src/lib/AKAZE.cpp
+++ b/src/lib/AKAZE.cpp
@@ -251,7 +251,7 @@ void AKAZE::Compute_Multiscale_Derivatives(void) {
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-  for (size_t i = 0; i < evolution_.size(); i++) {
+  for (int i = 0; i < evolution_.size(); i++) {
     float ratio = pow(2.f,evolution_[i].octave);
     int sigma_size_ = fRound(evolution_[i].esigma*factor_size_/ratio);
 
@@ -574,7 +574,7 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc) 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t i = 0; i < kpts.size(); i++) {
+      for (int i = 0; i < kpts.size(); i++) {
         Get_SURF_Descriptor_Upright_64(kpts[i],desc.ptr<float>(i));
       }
     }
@@ -584,7 +584,7 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc) 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t i = 0; i < kpts.size(); i++) {
+      for (int i = 0; i < kpts.size(); i++) {
         Compute_Main_Orientation_SURF(kpts[i]);
         Get_SURF_Descriptor_64(kpts[i],desc.ptr<float>(i));
       }
@@ -595,7 +595,7 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc) 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t i = 0; i < kpts.size(); i++) {
+      for (int i = 0; i < kpts.size(); i++) {
         Get_MSURF_Upright_Descriptor_64(kpts[i],desc.ptr<float>(i));
       }
     }
@@ -605,7 +605,7 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc) 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t i = 0; i < kpts.size(); i++) {
+      for (int i = 0; i < kpts.size(); i++) {
         Compute_Main_Orientation_SURF(kpts[i]);
         Get_MSURF_Descriptor_64(kpts[i],desc.ptr<float>(i));
       }
@@ -616,7 +616,7 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc) 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t i = 0; i < kpts.size(); i++) {
+      for (int i = 0; i < kpts.size(); i++) {
         if (descriptor_size_ == 0)
           Get_Upright_MLDB_Full_Descriptor(kpts[i],desc.ptr<unsigned char>(i));
         else
@@ -629,7 +629,7 @@ void AKAZE::Compute_Descriptors(std::vector<cv::KeyPoint>& kpts, cv::Mat& desc) 
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
-      for (size_t i = 0; i < kpts.size(); i++) {
+      for (int i = 0; i < kpts.size(); i++) {
         Compute_Main_Orientation_SURF(kpts[i]);
         if (descriptor_size_ == 0)
           Get_MLDB_Full_Descriptor(kpts[i],desc.ptr<unsigned char>(i));

--- a/src/lib/utils.cpp
+++ b/src/lib/utils.cpp
@@ -258,10 +258,10 @@ void compute_inliers_ransac(const std::vector<cv::Point2f>& matches,
   }
 
   if (use_fund == true){
-    H = findFundamentalMat(points1,points2,CV_FM_RANSAC,error,0.99,status);
+    H = findFundamentalMat(points1,points2,cv::FM_RANSAC,error,0.99,status);
   }
   else {
-    H = findHomography(points1,points2,CV_RANSAC,error,status);
+    H = findHomography(points1,points2,cv::RANSAC,error,status);
   }
 
   for (int i = 0; i < npoints; i++) {
@@ -351,7 +351,7 @@ void draw_inliers(const cv::Mat& img1, const cv::Mat& img2, cv::Mat& img_com,
 
   // This is in case the input images don't have the same resolution
   Mat img_aux = Mat(Size(img1.cols,img1.rows),CV_8UC3);
-  resize(img2,img_aux,Size(img1.cols,img1.rows),0,0,CV_INTER_LINEAR);
+  resize(img2,img_aux,Size(img1.cols,img1.rows),0,0,cv::INTER_LINEAR);
 
   for (int i = 0; i < img_com.rows; i++) {
     for (int j = 0; j < img_com.cols; j++) {
@@ -405,7 +405,7 @@ void draw_inliers(const cv::Mat& img1, const cv::Mat& img2, cv::Mat& img_com,
 
   // This is in case the input images don't have the same resolution
   Mat img_aux = Mat(Size(img1.cols,img1.rows),CV_8UC3);
-  resize(img2,img_aux,Size(img1.cols,img1.rows),0,0,CV_INTER_LINEAR);
+  resize(img2,img_aux,Size(img1.cols,img1.rows),0,0,cv::INTER_LINEAR);
 
   for (int i = 0; i < img_com.rows; i++) {
     for (int j = 0; j < img_com.cols; j++) {


### PR DESCRIPTION
The commit e75a921c8f74e260f4b06b71672507b91f69866c changed the type of some index variables from int to size_t, which triggers a Visual Studio compiler error (error C3016: 'i' : index variable in OpenMP 'for' statement must have signed integral type)

Also changed CV_FM_RANSAC to cv::FM_RANSAC to be independent of OpenCV legacy headers.
