### PR TITLE
Using specific opencv-submodule headers and support for opencv 2 &  3

### DIFF
--- a/src/akaze_compare.cpp
+++ b/src/akaze_compare.cpp
@@ -25,6 +25,7 @@
 // OpenCV
 #include <opencv2/features2d/features2d.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace std;
 
@@ -68,7 +69,6 @@ int main(int argc, char *argv[]) {
   double t1 = 0.0, t2 = 0.0;
 
   // ORB variables
-  cv::Ptr<cv::ORB> orb;
   vector<cv::KeyPoint> kpts1_orb, kpts2_orb;
   vector<cv::Point2f> matches_orb, inliers_orb;
   vector<vector<cv::DMatch> > dmatches_orb;
@@ -79,7 +79,6 @@ int main(int argc, char *argv[]) {
   double torb = 0.0;
 
   // BRISK variables
-  cv::Ptr<cv::BRISK> brisk;
   vector<cv::KeyPoint> kpts1_brisk, kpts2_brisk;
   vector<cv::Point2f> matches_brisk, inliers_brisk;
   vector<vector<cv::DMatch> > dmatches_brisk;
@@ -150,13 +149,13 @@ int main(int argc, char *argv[]) {
 
   // ORB Features
   //*****************
-  orb = cv::ORB::create(ORB_MAX_KPTS, ORB_SCALE_FACTOR, ORB_PYRAMID_LEVELS,
+  cv::ORB orb(ORB_MAX_KPTS, ORB_SCALE_FACTOR, ORB_PYRAMID_LEVELS,
                         ORB_EDGE_THRESHOLD, ORB_FIRST_PYRAMID_LEVEL, ORB_WTA_K, ORB_PATCH_SIZE);
 
   t1 = cv::getTickCount();
 
-  orb->detectAndCompute(img1, cv::noArray(), kpts1_orb, desc1_orb, false);
-  orb->detectAndCompute(img2, cv::noArray(), kpts2_orb, desc2_orb, false);
+  orb(img1, cv::noArray(), kpts1_orb, desc1_orb, false);
+  orb(img2, cv::noArray(), kpts2_orb, desc2_orb, false);
 
   matcher_l1->knnMatch(desc1_orb, desc2_orb, dmatches_orb, 2);
   matches2points_nndr(kpts1_orb,kpts2_orb,dmatches_orb,matches_orb,DRATIO);
@@ -198,12 +197,12 @@ int main(int argc, char *argv[]) {
 
   // BRISK Features
   //*****************
-  brisk = cv::BRISK::create(BRISK_HTHRES, BRISK_NOCTAVES, 1.0f);
+  cv::BRISK brisk(BRISK_HTHRES, BRISK_NOCTAVES, 1.0f);
 
   t1 = cv::getTickCount();
 
-  brisk->detectAndCompute(img1, cv::noArray(), kpts1_brisk, desc1_brisk, false);
-  brisk->detectAndCompute(img2, cv::noArray(), kpts2_brisk, desc2_brisk, false);
+  brisk(img1, cv::noArray(), kpts1_brisk, desc1_brisk, false);
+  brisk(img2, cv::noArray(), kpts2_brisk, desc2_brisk, false);
 
   matcher_l1->knnMatch(desc1_brisk, desc2_brisk, dmatches_brisk, 2);
   matches2points_nndr(kpts1_brisk, kpts2_brisk, dmatches_brisk, matches_brisk, DRATIO);

--- a/src/akaze_compare.cpp
+++ b/src/akaze_compare.cpp
@@ -149,13 +149,22 @@ int main(int argc, char *argv[]) {
 
   // ORB Features
   //*****************
+#if CV_VERSION_EPOCH == 2
   cv::ORB orb(ORB_MAX_KPTS, ORB_SCALE_FACTOR, ORB_PYRAMID_LEVELS,
-                        ORB_EDGE_THRESHOLD, ORB_FIRST_PYRAMID_LEVEL, ORB_WTA_K, ORB_PATCH_SIZE);
+#else
+  cv::Ptr<cv::ORB> orb = cv::ORB::create(ORB_MAX_KPTS, ORB_SCALE_FACTOR, ORB_PYRAMID_LEVELS,
+#endif
+    ORB_EDGE_THRESHOLD, ORB_FIRST_PYRAMID_LEVEL, ORB_WTA_K, ORB_PATCH_SIZE);
 
   t1 = cv::getTickCount();
 
+#if CV_VERSION_EPOCH == 2
   orb(img1, cv::noArray(), kpts1_orb, desc1_orb, false);
   orb(img2, cv::noArray(), kpts2_orb, desc2_orb, false);
+#else
+  orb->detectAndCompute(img1, cv::noArray(), kpts1_orb, desc1_orb, false);
+  orb->detectAndCompute(img2, cv::noArray(), kpts2_orb, desc2_orb, false);
+#endif
 
   matcher_l1->knnMatch(desc1_orb, desc2_orb, dmatches_orb, 2);
   matches2points_nndr(kpts1_orb,kpts2_orb,dmatches_orb,matches_orb,DRATIO);
@@ -197,12 +206,22 @@ int main(int argc, char *argv[]) {
 
   // BRISK Features
   //*****************
+#if CV_VERSION_EPOCH == 2
   cv::BRISK brisk(BRISK_HTHRES, BRISK_NOCTAVES, 1.0f);
+#else
+  cv::Ptr<cv::BRISK> brisk = cv::BRISK::create(BRISK_HTHRES, BRISK_NOCTAVES, 1.0f);
+#endif
 
   t1 = cv::getTickCount();
 
+#if CV_VERSION_EPOCH == 2
   brisk(img1, cv::noArray(), kpts1_brisk, desc1_brisk, false);
   brisk(img2, cv::noArray(), kpts2_brisk, desc2_brisk, false);
+#else
+  brisk->detectAndCompute(img1, cv::noArray(), kpts1_brisk, desc1_brisk, false);
+  brisk->detectAndCompute(img2, cv::noArray(), kpts2_brisk, desc2_brisk, false);
+#endif
+
 
   matcher_l1->knnMatch(desc1_brisk, desc2_brisk, dmatches_brisk, 2);
   matches2points_nndr(kpts1_brisk, kpts2_brisk, dmatches_brisk, matches_brisk, DRATIO);

--- a/src/akaze_features.cpp
+++ b/src/akaze_features.cpp
@@ -24,6 +24,7 @@
 
 // OpenCV
 #include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace std;
 

--- a/src/akaze_match.cpp
+++ b/src/akaze_match.cpp
@@ -23,6 +23,7 @@
 
 // OpenCV
 #include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace std;
 

--- a/src/lib/AKAZE.cpp
+++ b/src/lib/AKAZE.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "AKAZE.h"
+#include <opencv2/highgui/highgui.hpp>
 
 using namespace std;
 using namespace libAKAZE;

--- a/src/lib/AKAZEConfig.h
+++ b/src/lib/AKAZEConfig.h
@@ -9,7 +9,7 @@
 
 /* ************************************************************************* */
 // OpenCV
-#include <opencv2/opencv.hpp>
+#include <opencv2/core/core.hpp>
 
 // OpenMP
 #ifdef _OPENMP

--- a/src/lib/nldiffusion_functions.cpp
+++ b/src/lib/nldiffusion_functions.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "nldiffusion_functions.h"
+#include <opencv2/imgproc/imgproc.hpp>
 
 using namespace std;
 

--- a/src/lib/utils.cpp
+++ b/src/lib/utils.cpp
@@ -23,7 +23,8 @@
 #include "utils.h"
 
 // OpenCV
-#include <opencv2/opencv.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
 
 // System
 #include <fstream>


### PR DESCRIPTION
Hi, 

I tried to compile today AKAZE and I had problems. I use to have different opencv installations with different sub-modules enabled (depending on the needs of the specific project). So, if you try to include the general   opencv.hpp header and you don't have installed some of the sub-headers listed in that file, the compilation fails (Actually, that could be considered like a opencv bug ... I will take a look in order to see if that's reported). 

Then the call to cv::ORB::create() with several arguments also gave me problems with the last versions of opencv2. I think that the current version is suitable only for opencv3 (that it's still in beta version). I know that the API of the features2d module has been changing a lot in the last months/years, but I think it's a good idea to be keep compatibility with the opencv2 version. 